### PR TITLE
fix: stabilize native-transport Windows CI (welcome defer, bench timeouts, deno pin)

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -38,7 +38,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          # TODO: switch to "release"
+          # Pinned while jgd is not yet compatible with R 4.6.0.
+          # Keep this on 4.5.x in this PR; R 4.6 support will be handled
+          # in a dedicated follow-up PR, then switch back to "release".
           r-version: "4.5"
           use-public-rspm: true
 

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -49,11 +49,11 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           # Pinned to 2.7.11 pending a regression introduced in 2.7.12:
-          # the native uv_pipe_t rewrite (denoland/deno#33165) causes the
-          # node:net pipe listener to stop accepting subsequent client
-          # connections after the first one disconnects on Windows, which
-          # hangs the second jgd() call in the benchmark. Revisit once a
-          # fixed upstream release is available.
+          # on Windows, a node:net server on a named pipe stops firing
+          # 'connection' events after the first client disconnects, so
+          # the second jgd() call hangs its WriteFile waiting for a
+          # server-side reader that Deno never installs. Tracking in
+          # denoland/deno#33366. Revisit once fixed upstream.
           deno-version: v2.7.11
 
       - name: Install jgd R package

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -33,6 +33,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
+    env:
+      # Temporary debug switch to isolate benchmark behavior quickly.
+      JGD_SKIP_E2E_STEP: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -55,6 +58,7 @@ jobs:
         shell: bash
 
       - name: Run E2E tests
+        if: ${{ env.JGD_SKIP_E2E_STEP != '1' }}
         run: deno task test
         working-directory: tests
         env:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -51,7 +51,13 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          # Pinned to 2.7.11 pending a regression introduced in 2.7.12:
+          # the native uv_pipe_t rewrite (denoland/deno#33165) causes the
+          # node:net pipe listener to stop accepting subsequent client
+          # connections after the first one disconnects on Windows, which
+          # hangs the second jgd() call in the benchmark. Revisit once a
+          # fixed upstream release is available.
+          deno-version: v2.7.11
 
       - name: Install jgd R package
         run: R CMD INSTALL r-pkg

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -38,7 +38,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: release
+          # TODO: switch to "release"
+          r-version: "4.5"
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -63,4 +63,3 @@ jobs:
       - name: Run benchmarks
         run: deno task bench
         working-directory: tests
-        continue-on-error: true

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -33,9 +33,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
-    env:
-      # Temporary debug switch to isolate benchmark behavior quickly.
-      JGD_SKIP_E2E_STEP: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -64,7 +61,6 @@ jobs:
         shell: bash
 
       - name: Run E2E tests
-        if: ${{ env.JGD_SKIP_E2E_STEP != '1' }}
         run: deno task test
         working-directory: tests
         env:

--- a/.github/workflows/server-test.yaml
+++ b/.github/workflows/server-test.yaml
@@ -33,7 +33,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          # Pinned to 2.7.11 pending a regression introduced in 2.7.12:
+          # on Windows, a node:net server on a named pipe stops firing
+          # 'connection' events after the first client disconnects, so
+          # listener tests for repeated clients can hang. Tracking in
+          # denoland/deno#33366. Revisit once fixed upstream.
+          deno-version: v2.7.11
       - run: deno task test
         working-directory: server
       - run: deno task test:e2e

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -20,21 +20,6 @@
 #include <stdio.h>
 #include <unistd.h>
 
-/* Preserve an early resize message encountered while waiting for server_info.
-   On slower transports (notably Windows named pipes), a browser-originated
-   resize can arrive before the deferred welcome.  Treat it exactly like any
-   other pending resize instead of discarding it. */
-static void jgd_preserve_welcome_resize(jgd_state_t *st, const char *buf) {
-    double w = 0.0, h = 0.0;
-    int plot_index = -1;
-
-    if (!jgd_try_parse_resize(buf, &w, &h, &plot_index)) return;
-
-    st->pending_w = w;
-    st->pending_h = h;
-    st->pending_plot_index = plot_index;
-}
-
 /* Read server_info welcome message after connecting.
    The server defers the welcome until it receives R's first message,
    so we send a ping to trigger it, then read back with a short timeout. */
@@ -45,27 +30,29 @@ static void jgd_read_welcome(jgd_state_t *st) {
 
     /* Read up to a few lines: the server sends server_info after receiving
        the ping, but message ordering may vary across implementations.
-       Windows named pipes in CI can also take noticeably longer to deliver
-       the deferred welcome than local runs. */
+       Use one longer read window instead of many short retries: on Windows
+       named pipes, repeated timed-out overlapped reads can destabilize the
+       connection more than a single patient wait. */
     char buf[2048];
-    for (int attempt = 0; attempt < 10; attempt++) {
-        int n = transport_recv_line(&st->transport, buf, sizeof(buf), 250);
-        if (n < 0) {
-            if (!st->transport.connected) return; /* hard error */
-            continue; /* timeout while waiting for the deferred welcome */
-        }
+    const int welcome_timeout_ms = 2500;
+    for (int attempt = 0; attempt < 3; attempt++) {
+        int n = transport_recv_line(&st->transport, buf, sizeof(buf), welcome_timeout_ms);
+        if (n < 0) return;   /* timeout or hard error */
         if (n == 0) continue; /* empty line — skip */
 
         cJSON *msg = cJSON_Parse(buf);
-        if (!msg) {
-            jgd_preserve_welcome_resize(st, buf);
-            continue;
-        }
+        if (!msg) continue;
 
         cJSON *type = cJSON_GetObjectItem(msg, "type");
         if (!cJSON_IsString(type) || strcmp(type->valuestring, "server_info") != 0) {
+            double w = 0.0, h = 0.0;
+            int plot_index = -1;
+            if (jgd_try_parse_resize(buf, &w, &h, &plot_index)) {
+                st->pending_w = w;
+                st->pending_h = h;
+                st->pending_plot_index = plot_index;
+            }
             cJSON_Delete(msg);
-            jgd_preserve_welcome_resize(st, buf);
             continue;
         }
 

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -44,7 +44,17 @@ static void jgd_read_welcome(jgd_state_t *st) {
         if (n == 0) continue; /* empty line — skip */
 
         cJSON *msg = cJSON_Parse(buf);
-        if (!msg) continue;
+        if (!msg) {
+            double w = 0.0, h = 0.0;
+            if (jgd_try_parse_resize(buf, &w, &h, NULL)) {
+                st->pending_w = w;
+                st->pending_h = h;
+                /* Welcome-time resize must target current page only.
+                   Ignore plotIndex here to avoid stale historical state. */
+                st->pending_plot_index = -1;
+            }
+            continue;
+        }
 
         cJSON *type = cJSON_GetObjectItem(msg, "type");
         if (!cJSON_IsString(type) || strcmp(type->valuestring, "server_info") != 0) {

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -20,6 +20,21 @@
 #include <stdio.h>
 #include <unistd.h>
 
+/* Preserve an early resize message encountered while waiting for server_info.
+   On slower transports (notably Windows named pipes), a browser-originated
+   resize can arrive before the deferred welcome.  Treat it exactly like any
+   other pending resize instead of discarding it. */
+static void jgd_preserve_welcome_resize(jgd_state_t *st, const char *buf) {
+    double w = 0.0, h = 0.0;
+    int plot_index = -1;
+
+    if (!jgd_try_parse_resize(buf, &w, &h, &plot_index)) return;
+
+    st->pending_w = w;
+    st->pending_h = h;
+    st->pending_plot_index = plot_index;
+}
+
 /* Read server_info welcome message after connecting.
    The server defers the welcome until it receives R's first message,
    so we send a ping to trigger it, then read back with a short timeout. */
@@ -29,19 +44,28 @@ static void jgd_read_welcome(jgd_state_t *st) {
         return;
 
     /* Read up to a few lines: the server sends server_info after receiving
-       the ping, but message ordering may vary across implementations. */
+       the ping, but message ordering may vary across implementations.
+       Windows named pipes in CI can also take noticeably longer to deliver
+       the deferred welcome than local runs. */
     char buf[2048];
-    for (int attempt = 0; attempt < 3; attempt++) {
-        int n = transport_recv_line(&st->transport, buf, sizeof(buf), 200);
-        if (n < 0) return;   /* timeout or error — no point retrying */
+    for (int attempt = 0; attempt < 10; attempt++) {
+        int n = transport_recv_line(&st->transport, buf, sizeof(buf), 250);
+        if (n < 0) {
+            if (!st->transport.connected) return; /* hard error */
+            continue; /* timeout while waiting for the deferred welcome */
+        }
         if (n == 0) continue; /* empty line — skip */
 
         cJSON *msg = cJSON_Parse(buf);
-        if (!msg) continue;
+        if (!msg) {
+            jgd_preserve_welcome_resize(st, buf);
+            continue;
+        }
 
         cJSON *type = cJSON_GetObjectItem(msg, "type");
         if (!cJSON_IsString(type) || strcmp(type->valuestring, "server_info") != 0) {
             cJSON_Delete(msg);
+            jgd_preserve_welcome_resize(st, buf);
             continue;
         }
 

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -37,7 +37,10 @@ static void jgd_read_welcome(jgd_state_t *st) {
     const int welcome_timeout_ms = 2500;
     for (int attempt = 0; attempt < 3; attempt++) {
         int n = transport_recv_line(&st->transport, buf, sizeof(buf), welcome_timeout_ms);
-        if (n < 0) return;   /* timeout or hard error */
+        if (n < 0) {
+            if (!st->transport.connected) return; /* hard error */
+            continue; /* timeout while waiting for deferred welcome */
+        }
         if (n == 0) continue; /* empty line — skip */
 
         cJSON *msg = cJSON_Parse(buf);
@@ -46,11 +49,12 @@ static void jgd_read_welcome(jgd_state_t *st) {
         cJSON *type = cJSON_GetObjectItem(msg, "type");
         if (!cJSON_IsString(type) || strcmp(type->valuestring, "server_info") != 0) {
             double w = 0.0, h = 0.0;
-            int plot_index = -1;
-            if (jgd_try_parse_resize(buf, &w, &h, &plot_index)) {
+            if (jgd_try_parse_resize(buf, &w, &h, NULL)) {
                 st->pending_w = w;
                 st->pending_h = h;
-                st->pending_plot_index = plot_index;
+                /* Welcome-time resize must target current page only.
+                   Ignore plotIndex here to avoid stale historical state. */
+                st->pending_plot_index = -1;
             }
             cJSON_Delete(msg);
             continue;
@@ -160,9 +164,19 @@ SEXP C_jgd(SEXP s_width, SEXP s_height, SEXP s_dpi, SEXP s_socket) {
                    "Plots will be recorded but not displayed until connection is established.");
     }
 
+    /* On Windows named pipes, avoid a blocking welcome read during device
+       open because timed-out overlapped reads can destabilize startup in CI.
+       Server info is fetched lazily on demand by C_jgd_server_info. */
+#ifdef _WIN32
+    if (st->transport.connected &&
+        st->transport.pipe_handle == INVALID_HANDLE_VALUE) {
+        jgd_read_welcome(st);
+    }
+#else
     if (st->transport.connected) {
         jgd_read_welcome(st);
     }
+#endif
 
     pDevDesc dd = (pDevDesc)calloc(1, sizeof(DevDesc));
     if (!dd) {
@@ -869,7 +883,14 @@ SEXP C_jgd_server_info(SEXP s_path) {
 
     if (have_device) {
         st = (jgd_state_t *)gdd->dev->deviceSpecific;
-        if (!st || !st->server_info_received) {
+        if (!st) {
+            have_device = 0;
+        } else if (!st->server_info_received && st->transport.connected) {
+            /* Welcome is deferred on some transports/runtimes, so retry
+               once on demand before falling back to discovery.json. */
+            jgd_read_welcome(st);
+        }
+        if (have_device && !st->server_info_received) {
             have_device = 0;
         }
     }

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -67,7 +67,7 @@ static void jgd_read_welcome(jgd_state_t *st) {
     char buf[2048];
     const int welcome_total_timeout_ms = 2500;
     const long long deadline_ms = jgd_now_ms() + welcome_total_timeout_ms;
-    for (int attempt = 0; attempt < 3; attempt++) {
+    for (;;) {
         long long now_ms = jgd_now_ms();
         int remaining_ms = (int)(deadline_ms - now_ms);
         if (remaining_ms <= 0) return;
@@ -80,17 +80,7 @@ static void jgd_read_welcome(jgd_state_t *st) {
         if (n == 0) continue; /* empty line — skip */
 
         cJSON *msg = cJSON_Parse(buf);
-        if (!msg) {
-            double w = 0.0, h = 0.0;
-            if (jgd_try_parse_resize(buf, &w, &h, NULL)) {
-                st->pending_w = w;
-                st->pending_h = h;
-                /* Welcome-time resize must target current page only.
-                   Ignore plotIndex here to avoid stale historical state. */
-                st->pending_plot_index = -1;
-            }
-            continue;
-        }
+        if (!msg) continue;
 
         cJSON *type = cJSON_GetObjectItem(msg, "type");
         if (!cJSON_IsString(type) || strcmp(type->valuestring, "server_info") != 0) {

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -80,7 +80,17 @@ static void jgd_read_welcome(jgd_state_t *st) {
         if (n == 0) continue; /* empty line — skip */
 
         cJSON *msg = cJSON_Parse(buf);
-        if (!msg) continue;
+        if (!msg) {
+            double w = 0.0, h = 0.0;
+            if (jgd_try_parse_resize(buf, &w, &h, NULL)) {
+                st->pending_w = w;
+                st->pending_h = h;
+                /* Welcome-time resize must target current page only.
+                   Ignore plotIndex here to avoid stale historical state. */
+                st->pending_plot_index = -1;
+            }
+            continue;
+        }
 
         cJSON *type = cJSON_GetObjectItem(msg, "type");
         if (!cJSON_IsString(type) || strcmp(type->valuestring, "server_info") != 0) {

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -18,25 +18,61 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <time.h>
 #include <unistd.h>
+
+static int jgd_parse_resize_message(cJSON *msg, double *w, double *h, int *plot_index) {
+    cJSON *type = cJSON_GetObjectItem(msg, "type");
+    if (!cJSON_IsString(type) || strcmp(type->valuestring, "resize") != 0) {
+        return 0;
+    }
+    cJSON *wj = cJSON_GetObjectItem(msg, "width");
+    cJSON *hj = cJSON_GetObjectItem(msg, "height");
+    if (!cJSON_IsNumber(wj) || !cJSON_IsNumber(hj) ||
+        wj->valuedouble <= 0 || hj->valuedouble <= 0 ||
+        !R_FINITE(wj->valuedouble) || !R_FINITE(hj->valuedouble)) {
+        return 0;
+    }
+    *w = wj->valuedouble;
+    *h = hj->valuedouble;
+    if (plot_index) {
+        cJSON *pi = cJSON_GetObjectItem(msg, "plotIndex");
+        *plot_index = cJSON_IsNumber(pi) ? (int)pi->valuedouble : -1;
+    }
+    return 1;
+}
+
+static long long jgd_now_ms(void) {
+#ifdef _WIN32
+    return (long long)GetTickCount64();
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (long long)ts.tv_sec * 1000LL + (long long)(ts.tv_nsec / 1000000L);
+#endif
+}
 
 /* Read server_info welcome message after connecting.
    The server defers the welcome until it receives R's first message,
-   so we send a ping to trigger it, then read back with a short timeout. */
+   so we send a ping to trigger it, then read back within a bounded timeout. */
 static void jgd_read_welcome(jgd_state_t *st) {
     const char *ping = "{\"type\":\"ping\"}";
     if (transport_send(&st->transport, ping, strlen(ping)) != 0)
         return;
 
     /* Read up to a few lines: the server sends server_info after receiving
-       the ping, but message ordering may vary across implementations.
-       Use one longer read window instead of many short retries: on Windows
-       named pipes, repeated timed-out overlapped reads can destabilize the
-       connection more than a single patient wait. */
+       the ping, but message ordering may vary across implementations. Use a
+       single overall deadline so open-time waits stay bounded even if
+       server_info is delayed or absent. */
     char buf[2048];
-    const int welcome_timeout_ms = 2500;
+    const int welcome_total_timeout_ms = 2500;
+    const long long deadline_ms = jgd_now_ms() + welcome_total_timeout_ms;
     for (int attempt = 0; attempt < 3; attempt++) {
-        int n = transport_recv_line(&st->transport, buf, sizeof(buf), welcome_timeout_ms);
+        long long now_ms = jgd_now_ms();
+        int remaining_ms = (int)(deadline_ms - now_ms);
+        if (remaining_ms <= 0) return;
+
+        int n = transport_recv_line(&st->transport, buf, sizeof(buf), remaining_ms);
         if (n < 0) {
             if (!st->transport.connected) return; /* hard error */
             continue; /* timeout while waiting for deferred welcome */
@@ -59,7 +95,7 @@ static void jgd_read_welcome(jgd_state_t *st) {
         cJSON *type = cJSON_GetObjectItem(msg, "type");
         if (!cJSON_IsString(type) || strcmp(type->valuestring, "server_info") != 0) {
             double w = 0.0, h = 0.0;
-            if (jgd_try_parse_resize(buf, &w, &h, NULL)) {
+            if (jgd_parse_resize_message(msg, &w, &h, NULL)) {
                 st->pending_w = w;
                 st->pending_h = h;
                 /* Welcome-time resize must target current page only.
@@ -1070,25 +1106,7 @@ void jgd_remove_input_handler(jgd_state_t *st) {
 int jgd_try_parse_resize(const char *buf, double *w, double *h, int *plot_index) {
     cJSON *msg = cJSON_Parse(buf);
     if (!msg) return 0;
-    cJSON *type = cJSON_GetObjectItem(msg, "type");
-    if (!cJSON_IsString(type) || strcmp(type->valuestring, "resize") != 0) {
-        cJSON_Delete(msg);
-        return 0;
-    }
-    cJSON *wj = cJSON_GetObjectItem(msg, "width");
-    cJSON *hj = cJSON_GetObjectItem(msg, "height");
-    int ok = 0;
-    if (cJSON_IsNumber(wj) && cJSON_IsNumber(hj) &&
-        wj->valuedouble > 0 && hj->valuedouble > 0 &&
-        R_FINITE(wj->valuedouble) && R_FINITE(hj->valuedouble)) {
-        *w = wj->valuedouble;
-        *h = hj->valuedouble;
-        ok = 1;
-    }
-    if (plot_index) {
-        cJSON *pi = cJSON_GetObjectItem(msg, "plotIndex");
-        *plot_index = cJSON_IsNumber(pi) ? (int)pi->valuedouble : -1;
-    }
+    int ok = jgd_parse_resize_message(msg, w, h, plot_index);
     cJSON_Delete(msg);
     return ok;
 }

--- a/r-pkg/src/transport.c
+++ b/r-pkg/src/transport.c
@@ -593,6 +593,7 @@ int transport_recv_line(jgd_transport_t *t, char *buf, size_t bufsize, int timeo
     pfd.events = POLLIN;
     int pr = poll(&pfd, 1, timeout_ms);
     if (pr < 0) {
+        if (errno == EINTR) return -1;
         t->connected = 0;
         return -1;
     }
@@ -606,6 +607,8 @@ int transport_recv_line(jgd_transport_t *t, char *buf, size_t bufsize, int timeo
     tv.tv_usec = (timeout_ms % 1000) * 1000;
     int sr = select(0, &readfds, NULL, NULL, &tv);
     if (sr < 0) {
+        int err = SOCK_ERR;
+        if (err == WSAEINTR) return -1;
         t->connected = 0;
         return -1;
     }

--- a/r-pkg/src/transport.c
+++ b/r-pkg/src/transport.c
@@ -381,6 +381,16 @@ int transport_send(jgd_transport_t *t, const char *data, size_t len) {
     if (!t->connected) return -1;
 
 #ifdef _WIN32
+    /* Bound overlapped writes on Windows named pipes.  Without this, a
+     * server-side pipe instance that fails to drain reads promptly
+     * (observed with node:net after a prior R session disconnects on the
+     * same pipe path) can leave R hanging in WriteFile forever.  Five
+     * seconds is well above legitimate write latency for the small JSON
+     * lines we send, so a timeout signals a broken transport rather than
+     * a slow one; the caller (cb_strWidth, jgd_flush_frame, ...) falls
+     * back gracefully once t->connected is cleared. */
+    const DWORD send_timeout_ms = 5000;
+
     if (t->pipe_handle != INVALID_HANDLE_VALUE) {
         HANDLE h = (HANDLE)t->pipe_handle;
         size_t sent = 0;
@@ -394,7 +404,16 @@ int transport_send(jgd_transport_t *t, const char *data, size_t len) {
                     t->connected = 0;
                     return -1;
                 }
-                WaitForSingleObject(ov.hEvent, INFINITE);
+                DWORD wr = WaitForSingleObject(ov.hEvent, send_timeout_ms);
+                if (wr != WAIT_OBJECT_0) {
+                    /* Timeout or error: cancel the pending I/O and wait
+                     * for completion so the stack-local OVERLAPPED stays
+                     * valid until the kernel is done with it. */
+                    CancelIo(h);
+                    GetOverlappedResult(h, &ov, &written, TRUE);
+                    t->connected = 0;
+                    return -1;
+                }
                 if (!GetOverlappedResult(h, &ov, &written, FALSE)) {
                     t->connected = 0;
                     return -1;
@@ -417,7 +436,13 @@ int transport_send(jgd_transport_t *t, const char *data, size_t len) {
                     t->connected = 0;
                     return -1;
                 }
-                WaitForSingleObject(ov.hEvent, INFINITE);
+                DWORD wr = WaitForSingleObject(ov.hEvent, send_timeout_ms);
+                if (wr != WAIT_OBJECT_0) {
+                    CancelIo(h);
+                    GetOverlappedResult(h, &ov, &nw, TRUE);
+                    t->connected = 0;
+                    return -1;
+                }
                 if (!GetOverlappedResult(h, &ov, &nw, FALSE)) {
                     t->connected = 0;
                     return -1;

--- a/r-pkg/src/transport.c
+++ b/r-pkg/src/transport.c
@@ -593,7 +593,8 @@ int transport_recv_line(jgd_transport_t *t, char *buf, size_t bufsize, int timeo
     pfd.events = POLLIN;
     int pr = poll(&pfd, 1, timeout_ms);
     if (pr < 0) {
-        if (errno == EINTR) return -1;
+        int err = errno;
+        if (err == EINTR || err == EAGAIN) return -1;
         t->connected = 0;
         return -1;
     }
@@ -608,7 +609,7 @@ int transport_recv_line(jgd_transport_t *t, char *buf, size_t bufsize, int timeo
     int sr = select(0, &readfds, NULL, NULL, &tv);
     if (sr < 0) {
         int err = SOCK_ERR;
-        if (err == WSAEINTR) return -1;
+        if (err == WSAEINTR || err == WSAEWOULDBLOCK) return -1;
         t->connected = 0;
         return -1;
     }
@@ -626,7 +627,18 @@ int transport_recv_line(jgd_transport_t *t, char *buf, size_t bufsize, int timeo
         }
 
         int r = (int)recv(s, t->readbuf + t->readbuf_len, (int)space, 0);
-        if (r <= 0) {
+        if (r < 0) {
+#ifndef _WIN32
+            int err = errno;
+            if (err == EINTR || err == EAGAIN || err == EWOULDBLOCK) return -1;
+#else
+            int err = SOCK_ERR;
+            if (err == WSAEINTR || err == WSAEWOULDBLOCK) return -1;
+#endif
+            t->connected = 0;
+            return -1;
+        }
+        if (r == 0) {
             t->connected = 0;
             return -1;
         }

--- a/r-pkg/src/transport.c
+++ b/r-pkg/src/transport.c
@@ -381,16 +381,6 @@ int transport_send(jgd_transport_t *t, const char *data, size_t len) {
     if (!t->connected) return -1;
 
 #ifdef _WIN32
-    /* Bound overlapped writes on Windows named pipes.  Without this, a
-     * server-side pipe instance that fails to drain reads promptly
-     * (observed with node:net after a prior R session disconnects on the
-     * same pipe path) can leave R hanging in WriteFile forever.  Five
-     * seconds is well above legitimate write latency for the small JSON
-     * lines we send, so a timeout signals a broken transport rather than
-     * a slow one; the caller (cb_strWidth, jgd_flush_frame, ...) falls
-     * back gracefully once t->connected is cleared. */
-    const DWORD send_timeout_ms = 5000;
-
     if (t->pipe_handle != INVALID_HANDLE_VALUE) {
         HANDLE h = (HANDLE)t->pipe_handle;
         size_t sent = 0;
@@ -404,16 +394,7 @@ int transport_send(jgd_transport_t *t, const char *data, size_t len) {
                     t->connected = 0;
                     return -1;
                 }
-                DWORD wr = WaitForSingleObject(ov.hEvent, send_timeout_ms);
-                if (wr != WAIT_OBJECT_0) {
-                    /* Timeout or error: cancel the pending I/O and wait
-                     * for completion so the stack-local OVERLAPPED stays
-                     * valid until the kernel is done with it. */
-                    CancelIo(h);
-                    GetOverlappedResult(h, &ov, &written, TRUE);
-                    t->connected = 0;
-                    return -1;
-                }
+                WaitForSingleObject(ov.hEvent, INFINITE);
                 if (!GetOverlappedResult(h, &ov, &written, FALSE)) {
                     t->connected = 0;
                     return -1;
@@ -436,13 +417,7 @@ int transport_send(jgd_transport_t *t, const char *data, size_t len) {
                     t->connected = 0;
                     return -1;
                 }
-                DWORD wr = WaitForSingleObject(ov.hEvent, send_timeout_ms);
-                if (wr != WAIT_OBJECT_0) {
-                    CancelIo(h);
-                    GetOverlappedResult(h, &ov, &nw, TRUE);
-                    t->connected = 0;
-                    return -1;
-                }
+                WaitForSingleObject(ov.hEvent, INFINITE);
                 if (!GetOverlappedResult(h, &ov, &nw, FALSE)) {
                     t->connected = 0;
                     return -1;

--- a/r-pkg/src/transport.c
+++ b/r-pkg/src/transport.c
@@ -592,7 +592,11 @@ int transport_recv_line(jgd_transport_t *t, char *buf, size_t bufsize, int timeo
     pfd.fd = s;
     pfd.events = POLLIN;
     int pr = poll(&pfd, 1, timeout_ms);
-    if (pr <= 0) return -1;
+    if (pr < 0) {
+        t->connected = 0;
+        return -1;
+    }
+    if (pr == 0) return -1;
 #else
     fd_set readfds;
     FD_ZERO(&readfds);
@@ -601,7 +605,11 @@ int transport_recv_line(jgd_transport_t *t, char *buf, size_t bufsize, int timeo
     tv.tv_sec = timeout_ms / 1000;
     tv.tv_usec = (timeout_ms % 1000) * 1000;
     int sr = select(0, &readfds, NULL, NULL, &tv);
-    if (sr <= 0) return -1;
+    if (sr < 0) {
+        t->connected = 0;
+        return -1;
+    }
+    if (sr == 0) return -1;
 #endif
 
     /* Bulk-read until we have a complete line */
@@ -645,4 +653,3 @@ void transport_close(jgd_transport_t *t) {
     t->connected = 0;
     t->readbuf_len = 0;
 }
-

--- a/server/tests/helpers/server.ts
+++ b/server/tests/helpers/server.ts
@@ -169,9 +169,31 @@ export class TestServer {
     this.pid = this.#process.pid;
   }
 
-  /** Snapshot of server stderr captured so far (drained in background). */
-  stderrSnapshot(): string {
-    return this.#stderrBuf.join("");
+  /**
+   * Snapshot of server stderr captured so far (drained in background).
+   * When maxChars is set, materialize only that tail to avoid large joins.
+   */
+  stderrSnapshot(maxChars?: number): string {
+    if (maxChars === undefined) {
+      return this.#stderrBuf.join("");
+    }
+    if (maxChars <= 0 || this.#stderrBuf.length === 0) {
+      return "";
+    }
+
+    const tail: string[] = [];
+    let remaining = maxChars;
+    for (let i = this.#stderrBuf.length - 1; i >= 0 && remaining > 0; i--) {
+      const chunk = this.#stderrBuf[i];
+      if (chunk.length <= remaining) {
+        tail.push(chunk);
+        remaining -= chunk.length;
+      } else {
+        tail.push(chunk.slice(chunk.length - remaining));
+        remaining = 0;
+      }
+    }
+    return tail.reverse().join("");
   }
 
   get httpBaseUrl(): string {

--- a/server/tests/helpers/server.ts
+++ b/server/tests/helpers/server.ts
@@ -169,6 +169,11 @@ export class TestServer {
     this.pid = this.#process.pid;
   }
 
+  /** Snapshot of server stderr captured so far (drained in background). */
+  stderrSnapshot(): string {
+    return this.#stderrBuf.join("");
+  }
+
   get httpBaseUrl(): string {
     return `http://127.0.0.1:${this.httpPort}`;
   }

--- a/tests/bench/bench-plot.R
+++ b/tests/bench/bench-plot.R
@@ -16,7 +16,13 @@ if (nzchar(.jgd_bench_socket)) {
 set.seed(42)
 hist_data = rnorm(1000)
 
+step_log = function(msg) {
+  cat(sprintf("[bench-step] %s | %s\n", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), msg))
+  flush.console()
+}
+
 bench = function(label, expr_fn, times = 1L) {
+  step_log(sprintf("BEGIN %s", label))
   timings = numeric(times)
   for (i in seq_len(times)) {
     t0 = proc.time()
@@ -24,16 +30,19 @@ bench = function(label, expr_fn, times = 1L) {
     t1 = proc.time()
     timings[i] = (t1 - t0)[["elapsed"]]
   }
+  step_log(sprintf("END %s (median=%.3fs)", label, median(timings)))
   list(label = label, elapsed = median(timings), timings = timings)
 }
 
 results = list()
 
 # --- jgd benchmarks ---
+step_log("SECTION jgd: start")
 if (requireNamespace("jgd", quietly = TRUE)) {
   library(jgd)
   # jgd discovers the socket via options(jgd.socket=...) or discovery file
   run_jgd_bench = function(label, plot_fn) {
+    step_log(sprintf("jgd() open device for %s", label))
     jgd()
     on.exit(dev.off(), add = TRUE)
     bench(paste0("jgd:", label), plot_fn)
@@ -44,11 +53,14 @@ if (requireNamespace("jgd", quietly = TRUE)) {
     run_jgd_bench("plot(mtcars)", function() plot(mtcars)),
     run_jgd_bench("hist(rnorm(1000))", function() hist(hist_data, main = "Benchmark"))
   ))
+  step_log("SECTION jgd: done")
 } else {
   message("jgd package not installed, skipping")
+  step_log("SECTION jgd: skipped")
 }
 
 # --- ragg benchmarks ---
+step_log("SECTION ragg: start")
 if (requireNamespace("ragg", quietly = TRUE)) {
   library(ragg)
 
@@ -65,11 +77,14 @@ if (requireNamespace("ragg", quietly = TRUE)) {
     run_ragg_bench("plot(mtcars)", function() plot(mtcars)),
     run_ragg_bench("hist(rnorm(1000))", function() hist(hist_data, main = "Benchmark"))
   ))
+  step_log("SECTION ragg: done")
 } else {
   message("ragg package not installed, skipping")
+  step_log("SECTION ragg: skipped")
 }
 
 # --- base png benchmarks ---
+step_log("SECTION png: start")
 run_png_bench = function(label, plot_fn) {
   f = tempfile(fileext = ".png")
   png(f, width = 800, height = 600)
@@ -83,8 +98,10 @@ results = c(results, list(
   run_png_bench("plot(mtcars)", function() plot(mtcars)),
   run_png_bench("hist(rnorm(1000))", function() hist(hist_data, main = "Benchmark"))
 ))
+step_log("SECTION png: done")
 
 # --- Output ---
+step_log("OUTPUT: rendering summary")
 cat("\n=== Benchmark Results ===\n")
 for (r in results) {
   cat(sprintf("  %-30s  %.3fs\n", r$label, r$elapsed))
@@ -106,3 +123,4 @@ json_str = paste0(
 )
 cat("\n=== JSON ===\n")
 cat(json_str, "\n")
+step_log("OUTPUT: done")

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -31,7 +31,10 @@ function parseBenchTimeoutMs(): number {
   if (raw === undefined || raw.trim() === "") return 180000;
 
   const parsed = Number(raw);
-  if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    const timeoutMs = Math.floor(parsed);
+    if (timeoutMs >= 1) return timeoutMs;
+  }
 
   throw new Error(
     `Invalid JGD_BENCH_TIMEOUT_MS="${raw}". Expected a positive number (milliseconds).`,

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -25,7 +25,7 @@ const args = parseArgs(Deno.args, {
 });
 
 const noClient = args["no-client"];
-const benchTimeoutMs = parseBenchTimeoutMs();
+const timeoutRecoveryWaitMs = 3000;
 
 function parseBenchTimeoutMs(): number {
   const raw = Deno.env.get("JGD_BENCH_TIMEOUT_MS");
@@ -66,137 +66,164 @@ function createStreamCollector(stream: ReadableStream<Uint8Array> | null) {
   };
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-// --- Main ---
-console.log(`\n${"=".repeat(60)}`);
-console.log("  jgd Benchmark Suite");
-console.log(`${"=".repeat(60)}`);
-
-// Start server
-console.log("==> Starting server...");
-const server = new TestServer();
-await server.start();
-console.log(`    Socket: ${server.socketPath}`);
-console.log(`    HTTP:   ${server.httpBaseUrl}`);
-
-let client: MockMetricsClient | null = null;
-try {
-  // Connect mock client
-  if (!noClient) {
-    console.log("==> Connecting mock metrics client...");
-    client = new MockMetricsClient(server.wsUrl);
-    await client.connect();
-    await new Promise((r) => setTimeout(r, 500));
-    console.log("    Connected");
-  }
-
-  // Run R benchmarks
-  console.log("==> Running R benchmarks...");
-  const benchScript = join(scriptDir, "bench-plot.R");
-  const socketAddr = toRSocketAddress(server.socketPath);
-  const rCmd = new Deno.Command("Rscript", {
-    args: [benchScript],
-    stdout: "piped",
-    stderr: "piped",
-    env: { ...Deno.env.toObject(), JGD_BENCH_SOCKET: socketAddr },
+async function waitUpTo<T>(promise: Promise<T>, waitMs: number): Promise<void> {
+  let timeoutId: number | undefined;
+  await Promise.race([
+    promise.then(() => undefined),
+    new Promise<void>((resolve) => {
+      timeoutId = setTimeout(resolve, waitMs);
+    }),
+  ]).finally(() => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
   });
-  const rProc = rCmd.spawn();
-  const stdoutCollector = createStreamCollector(rProc.stdout);
-  const stderrCollector = createStreamCollector(rProc.stderr);
-  let timeoutTriggered = false;
-  let timeoutCleanup: Promise<void> | null = null;
-  const killRProcess = async (): Promise<boolean> => {
-    let killRequested = false;
-    try {
-      rProc.kill();
-      killRequested = true;
-    } catch {
-      // Continue to platform-specific hard kill below.
-    }
-    if (Deno.build.os === "windows") {
-      try {
-        const result = await new Deno.Command("taskkill", {
-          args: ["/PID", String(rProc.pid), "/T", "/F"],
-          stdout: "null",
-          stderr: "null",
-        }).output();
-        killRequested = killRequested || result.success;
-      } catch {
-        // Best effort only.
-      }
-    }
-    return killRequested;
-  };
-  let rStatus: Deno.CommandStatus;
-  try {
-    rStatus = await raceWithTimeout(
-      rProc.status,
-      benchTimeoutMs,
-      () => {
-        timeoutTriggered = true;
-        timeoutCleanup = (async () => {
-          const killRequested = await killRProcess();
-          const stdout = stdoutCollector.snapshot();
-          const stderr = stderrCollector.snapshot();
-          console.error(
-            `R benchmark timed out after ${benchTimeoutMs}ms` +
-              (killRequested ? " (kill requested)" : ""),
-          );
-          if (stdout.trim()) {
-            console.error("\n--- Partial R stdout ---");
-            console.error(stdout.trim().slice(-4000));
-          }
-          if (stderr.trim()) {
-            console.error("\n--- Partial R stderr ---");
-            console.error(stderr.trim().slice(-4000));
-          }
-        })();
-        return timeoutCleanup;
-      },
-      `R benchmark timeout after ${benchTimeoutMs}ms`,
-    );
-  } catch (error) {
-    if (timeoutTriggered && timeoutCleanup) {
-      await Promise.race([timeoutCleanup, sleep(3000)]);
-      await Promise.all([stdoutCollector.done, stderrCollector.done]);
-    }
-    throw error;
-  }
-  await Promise.all([stdoutCollector.done, stderrCollector.done]);
-  const stdout = stdoutCollector.snapshot();
-  const stderr = stderrCollector.snapshot();
-
-  if (!rStatus.success) {
-    console.error(`R process exited with code ${rStatus.code}`);
-    if (stderr.trim()) console.error(stderr.trim());
-    throw new Error(`R process failed with code ${rStatus.code}`);
-  }
-
-  if (stderr.trim()) {
-    console.log("\n--- R stderr ---");
-    console.log(stderr.trim());
-  }
-
-  console.log("\n--- R output ---");
-  console.log(stdout.trim());
-
-  // Client stats
-  if (client) {
-    const stats = client.stats();
-    console.log("\n=== Mock Client Stats ===");
-    console.log(
-      `  Metrics requests: ${stats.metricsRequests} (strWidth: ${stats.strWidthRequests}, metricInfo: ${stats.metricInfoRequests})`,
-    );
-    console.log(`  Frames received:  ${stats.framesReceived}`);
-    console.log(`  Total ops:        ${stats.totalOps}`);
-  }
-} finally {
-  if (client) client.close();
-  await server.shutdown();
-  server.cleanup();
 }
 
-console.log("\n==> Done.");
+export async function settleTimeoutPath(
+  timeoutCleanup: Promise<void>,
+  collectors: Array<Promise<unknown>>,
+  waitMs = timeoutRecoveryWaitMs,
+): Promise<void> {
+  await waitUpTo(timeoutCleanup, waitMs);
+  await waitUpTo(Promise.all(collectors), waitMs);
+}
+
+async function main() {
+  const benchTimeoutMs = parseBenchTimeoutMs();
+
+  // --- Main ---
+  console.log(`\n${"=".repeat(60)}`);
+  console.log("  jgd Benchmark Suite");
+  console.log(`${"=".repeat(60)}`);
+
+  // Start server
+  console.log("==> Starting server...");
+  const server = new TestServer();
+  await server.start();
+  console.log(`    Socket: ${server.socketPath}`);
+  console.log(`    HTTP:   ${server.httpBaseUrl}`);
+
+  let client: MockMetricsClient | null = null;
+  try {
+    // Connect mock client
+    if (!noClient) {
+      console.log("==> Connecting mock metrics client...");
+      client = new MockMetricsClient(server.wsUrl);
+      await client.connect();
+      await new Promise((r) => setTimeout(r, 500));
+      console.log("    Connected");
+    }
+
+    // Run R benchmarks
+    console.log("==> Running R benchmarks...");
+    const benchScript = join(scriptDir, "bench-plot.R");
+    const socketAddr = toRSocketAddress(server.socketPath);
+    const rCmd = new Deno.Command("Rscript", {
+      args: [benchScript],
+      stdout: "piped",
+      stderr: "piped",
+      env: { ...Deno.env.toObject(), JGD_BENCH_SOCKET: socketAddr },
+    });
+    const rProc = rCmd.spawn();
+    const stdoutCollector = createStreamCollector(rProc.stdout);
+    const stderrCollector = createStreamCollector(rProc.stderr);
+    let timeoutTriggered = false;
+    let timeoutCleanup: Promise<void> | null = null;
+    const killRProcess = async (): Promise<boolean> => {
+      let killRequested = false;
+      try {
+        rProc.kill();
+        killRequested = true;
+      } catch {
+        // Continue to platform-specific hard kill below.
+      }
+      if (Deno.build.os === "windows") {
+        try {
+          const result = await new Deno.Command("taskkill", {
+            args: ["/PID", String(rProc.pid), "/T", "/F"],
+            stdout: "null",
+            stderr: "null",
+          }).output();
+          killRequested = killRequested || result.success;
+        } catch {
+          // Best effort only.
+        }
+      }
+      return killRequested;
+    };
+    let rStatus: Deno.CommandStatus;
+    try {
+      rStatus = await raceWithTimeout(
+        rProc.status,
+        benchTimeoutMs,
+        () => {
+          timeoutTriggered = true;
+          timeoutCleanup = (async () => {
+            const killRequested = await killRProcess();
+            const stdout = stdoutCollector.snapshot();
+            const stderr = stderrCollector.snapshot();
+            console.error(
+              `R benchmark timed out after ${benchTimeoutMs}ms` +
+                (killRequested ? " (kill requested)" : ""),
+            );
+            if (stdout.trim()) {
+              console.error("\n--- Partial R stdout ---");
+              console.error(stdout.trim().slice(-4000));
+            }
+            if (stderr.trim()) {
+              console.error("\n--- Partial R stderr ---");
+              console.error(stderr.trim().slice(-4000));
+            }
+          })();
+          return timeoutCleanup;
+        },
+        `R benchmark timeout after ${benchTimeoutMs}ms`,
+      );
+    } catch (error) {
+      if (timeoutTriggered && timeoutCleanup) {
+        await settleTimeoutPath(timeoutCleanup, [
+          stdoutCollector.done,
+          stderrCollector.done,
+        ]);
+      }
+      throw error;
+    }
+    await Promise.all([stdoutCollector.done, stderrCollector.done]);
+    const stdout = stdoutCollector.snapshot();
+    const stderr = stderrCollector.snapshot();
+
+    if (!rStatus.success) {
+      console.error(`R process exited with code ${rStatus.code}`);
+      if (stderr.trim()) console.error(stderr.trim());
+      throw new Error(`R process failed with code ${rStatus.code}`);
+    }
+
+    if (stderr.trim()) {
+      console.log("\n--- R stderr ---");
+      console.log(stderr.trim());
+    }
+
+    console.log("\n--- R output ---");
+    console.log(stdout.trim());
+
+    // Client stats
+    if (client) {
+      const stats = client.stats();
+      console.log("\n=== Mock Client Stats ===");
+      console.log(
+        `  Metrics requests: ${stats.metricsRequests} (strWidth: ${stats.strWidthRequests}, metricInfo: ${stats.metricInfoRequests})`,
+      );
+      console.log(`  Frames received:  ${stats.framesReceived}`);
+      console.log(`  Total ops:        ${stats.totalOps}`);
+    }
+  } finally {
+    if (client) client.close();
+    await server.shutdown();
+    server.cleanup();
+  }
+
+  console.log("\n==> Done.");
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -28,7 +28,7 @@ const benchTimeoutMs = parseBenchTimeoutMs();
 
 function parseBenchTimeoutMs(): number {
   const raw = Deno.env.get("JGD_BENCH_TIMEOUT_MS");
-  if (raw === undefined || raw.trim() === "") return 180000;
+  if (raw === undefined || raw.trim() === "") return 30000;
 
   const parsed = Number(raw);
   if (Number.isFinite(parsed) && parsed > 0) {

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -66,6 +66,10 @@ function createStreamCollector(stream: ReadableStream<Uint8Array> | null) {
   };
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // --- Main ---
 console.log(`\n${"=".repeat(60)}`);
 console.log("  jgd Benchmark Suite");
@@ -102,6 +106,8 @@ try {
   const rProc = rCmd.spawn();
   const stdoutCollector = createStreamCollector(rProc.stdout);
   const stderrCollector = createStreamCollector(rProc.stderr);
+  let timeoutTriggered = false;
+  let timeoutCleanup: Promise<void> | null = null;
   const killRProcess = async (): Promise<boolean> => {
     let killRequested = false;
     try {
@@ -124,28 +130,41 @@ try {
     }
     return killRequested;
   };
-  const rStatus = await raceWithTimeout(
-    rProc.status,
-    benchTimeoutMs,
-    async () => {
-      const killRequested = await killRProcess();
-      const stdout = stdoutCollector.snapshot();
-      const stderr = stderrCollector.snapshot();
-      console.error(
-        `R benchmark timed out after ${benchTimeoutMs}ms` +
-          (killRequested ? " (kill requested)" : ""),
-      );
-      if (stdout.trim()) {
-        console.error("\n--- Partial R stdout ---");
-        console.error(stdout.trim().slice(-4000));
-      }
-      if (stderr.trim()) {
-        console.error("\n--- Partial R stderr ---");
-        console.error(stderr.trim().slice(-4000));
-      }
-    },
-    `R benchmark timeout after ${benchTimeoutMs}ms`,
-  );
+  let rStatus: Deno.CommandStatus;
+  try {
+    rStatus = await raceWithTimeout(
+      rProc.status,
+      benchTimeoutMs,
+      () => {
+        timeoutTriggered = true;
+        timeoutCleanup = (async () => {
+          const killRequested = await killRProcess();
+          const stdout = stdoutCollector.snapshot();
+          const stderr = stderrCollector.snapshot();
+          console.error(
+            `R benchmark timed out after ${benchTimeoutMs}ms` +
+              (killRequested ? " (kill requested)" : ""),
+          );
+          if (stdout.trim()) {
+            console.error("\n--- Partial R stdout ---");
+            console.error(stdout.trim().slice(-4000));
+          }
+          if (stderr.trim()) {
+            console.error("\n--- Partial R stderr ---");
+            console.error(stderr.trim().slice(-4000));
+          }
+        })();
+        return timeoutCleanup;
+      },
+      `R benchmark timeout after ${benchTimeoutMs}ms`,
+    );
+  } catch (error) {
+    if (timeoutTriggered && timeoutCleanup) {
+      await Promise.race([timeoutCleanup, sleep(3000)]);
+      await Promise.all([stdoutCollector.done, stderrCollector.done]);
+    }
+    throw error;
+  }
   await Promise.all([stdoutCollector.done, stderrCollector.done]);
   const stdout = stdoutCollector.snapshot();
   const stderr = stderrCollector.snapshot();

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -24,10 +24,19 @@ const args = parseArgs(Deno.args, {
 });
 
 const noClient = args["no-client"];
-const benchTimeoutMs = Number.parseInt(
-  Deno.env.get("JGD_BENCH_TIMEOUT_MS") ?? "180000",
-  10,
-);
+const benchTimeoutMs = parseBenchTimeoutMs();
+
+function parseBenchTimeoutMs(): number {
+  const raw = Deno.env.get("JGD_BENCH_TIMEOUT_MS");
+  if (raw === undefined || raw.trim() === "") return 180000;
+
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+
+  throw new Error(
+    `Invalid JGD_BENCH_TIMEOUT_MS="${raw}". Expected a positive number (milliseconds).`,
+  );
+}
 
 // --- Main ---
 console.log(`\n${"=".repeat(60)}`);
@@ -63,38 +72,45 @@ try {
     env: { ...Deno.env.toObject(), JGD_BENCH_SOCKET: socketAddr },
   });
   const rProc = rCmd.spawn();
-  let timedOut = false;
-  const killRProcess = async () => {
+  let timeoutTriggered = false;
+  let timeoutKillPromise: Promise<boolean> | null = null;
+  const killRProcess = async (): Promise<boolean> => {
+    let killRequested = false;
     try {
       rProc.kill();
-      return;
+      killRequested = true;
     } catch {
-      // Fall through to platform-specific hard kill below.
+      // Continue to platform-specific hard kill below.
     }
     if (Deno.build.os === "windows") {
       try {
-        await new Deno.Command("taskkill", {
+        const result = await new Deno.Command("taskkill", {
           args: ["/PID", String(rProc.pid), "/T", "/F"],
           stdout: "null",
           stderr: "null",
         }).output();
+        killRequested = killRequested || result.success;
       } catch {
         // Best effort only.
       }
     }
+    return killRequested;
   };
   const timeoutId = setTimeout(() => {
-    timedOut = true;
-    void killRProcess();
+    timeoutTriggered = true;
+    timeoutKillPromise = killRProcess();
   }, benchTimeoutMs);
 
   const rResult = await rProc.output();
   clearTimeout(timeoutId);
+  const timeoutKillIssued = timeoutKillPromise
+    ? await timeoutKillPromise
+    : false;
   const stdout = new TextDecoder().decode(rResult.stdout);
   const stderr = new TextDecoder().decode(rResult.stderr);
 
   if (!rResult.success) {
-    if (timedOut) {
+    if (timeoutTriggered && timeoutKillIssued) {
       console.error(
         `R benchmark timed out after ${benchTimeoutMs}ms (killed process)`,
       );

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -24,6 +24,10 @@ const args = parseArgs(Deno.args, {
 });
 
 const noClient = args["no-client"];
+const benchTimeoutMs = Number.parseInt(
+  Deno.env.get("JGD_BENCH_TIMEOUT_MS") ?? "180000",
+  10,
+);
 
 // --- Main ---
 console.log(`\n${"=".repeat(60)}`);
@@ -58,12 +62,37 @@ try {
     stderr: "piped",
     env: { ...Deno.env.toObject(), JGD_BENCH_SOCKET: socketAddr },
   });
+  const rProc = rCmd.spawn();
+  let timedOut = false;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    try {
+      rProc.kill("SIGKILL");
+    } catch {
+      // Process already exited.
+    }
+  }, benchTimeoutMs);
 
-  const rResult = await rCmd.output();
+  const rResult = await rProc.output();
+  clearTimeout(timeoutId);
   const stdout = new TextDecoder().decode(rResult.stdout);
   const stderr = new TextDecoder().decode(rResult.stderr);
 
   if (!rResult.success) {
+    if (timedOut) {
+      console.error(
+        `R benchmark timed out after ${benchTimeoutMs}ms (killed process)`,
+      );
+      if (stdout.trim()) {
+        console.error("\n--- Partial R stdout ---");
+        console.error(stdout.trim().slice(-4000));
+      }
+      if (stderr.trim()) {
+        console.error("\n--- Partial R stderr ---");
+        console.error(stderr.trim().slice(-4000));
+      }
+      throw new Error(`R benchmark timeout after ${benchTimeoutMs}ms`);
+    }
     console.error(`R process exited with code ${rResult.code}`);
     if (stderr.trim()) console.error(stderr.trim());
     throw new Error(`R process failed with code ${rResult.code}`);

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -173,6 +173,14 @@ async function main() {
               console.error("\n--- Partial R stderr ---");
               console.error(stderr.trim().slice(-4000));
             }
+            if (client) {
+              const stats = client.stats();
+              console.error("\n--- Partial Mock Client Stats ---");
+              console.error(
+                `metrics=${stats.metricsRequests} (strWidth=${stats.strWidthRequests}, metricInfo=${stats.metricInfoRequests}), ` +
+                  `frames=${stats.framesReceived}, totalOps=${stats.totalOps}, lastFrameOps=${stats.lastFrameOps}`,
+              );
+            }
           })();
           return timeoutCleanup;
         },

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -14,6 +14,7 @@ import { dirname, fromFileUrl, join } from "@std/path";
 import { parseArgs } from "@std/cli/parse-args";
 import { TestServer } from "../../server/tests/helpers/server.ts";
 import { MockMetricsClient } from "./mock-metrics-client.ts";
+import { raceWithTimeout } from "./timeout.ts";
 import { toRSocketAddress } from "../helpers/r_process.ts";
 
 const scriptDir = dirname(fromFileUrl(import.meta.url));
@@ -65,10 +66,6 @@ function createStreamCollector(stream: ReadableStream<Uint8Array> | null) {
   };
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 // --- Main ---
 console.log(`\n${"=".repeat(60)}`);
 console.log("  jgd Benchmark Suite");
@@ -105,8 +102,6 @@ try {
   const rProc = rCmd.spawn();
   const stdoutCollector = createStreamCollector(rProc.stdout);
   const stderrCollector = createStreamCollector(rProc.stderr);
-  let timeoutTriggered = false;
-  let timeoutKillIssued = false;
   const killRProcess = async (): Promise<boolean> => {
     let killRequested = false;
     try {
@@ -129,45 +124,33 @@ try {
     }
     return killRequested;
   };
-  let timeoutId = -1;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(() => {
-      timeoutTriggered = true;
-      void (async () => {
-        timeoutKillIssued = await Promise.race([
-          killRProcess(),
-          sleep(2000).then(() => false),
-        ]);
-
-        const stdout = stdoutCollector.snapshot();
-        const stderr = stderrCollector.snapshot();
-        console.error(
-          `R benchmark timed out after ${benchTimeoutMs}ms` +
-            (timeoutKillIssued ? " (kill requested)" : ""),
-        );
-        if (stdout.trim()) {
-          console.error("\n--- Partial R stdout ---");
-          console.error(stdout.trim().slice(-4000));
-        }
-        if (stderr.trim()) {
-          console.error("\n--- Partial R stderr ---");
-          console.error(stderr.trim().slice(-4000));
-        }
-        reject(new Error(`R benchmark timeout after ${benchTimeoutMs}ms`));
-      })();
-    }, benchTimeoutMs);
-  });
-
-  const rStatus = await Promise.race([rProc.status, timeoutPromise]);
-  clearTimeout(timeoutId);
+  const rStatus = await raceWithTimeout(
+    rProc.status,
+    benchTimeoutMs,
+    async () => {
+      const killRequested = await killRProcess();
+      const stdout = stdoutCollector.snapshot();
+      const stderr = stderrCollector.snapshot();
+      console.error(
+        `R benchmark timed out after ${benchTimeoutMs}ms` +
+          (killRequested ? " (kill requested)" : ""),
+      );
+      if (stdout.trim()) {
+        console.error("\n--- Partial R stdout ---");
+        console.error(stdout.trim().slice(-4000));
+      }
+      if (stderr.trim()) {
+        console.error("\n--- Partial R stderr ---");
+        console.error(stderr.trim().slice(-4000));
+      }
+    },
+    `R benchmark timeout after ${benchTimeoutMs}ms`,
+  );
   await Promise.all([stdoutCollector.done, stderrCollector.done]);
   const stdout = stdoutCollector.snapshot();
   const stderr = stderrCollector.snapshot();
 
   if (!rStatus.success) {
-    if (timeoutTriggered && timeoutKillIssued) {
-      throw new Error(`R benchmark timeout after ${benchTimeoutMs}ms`);
-    }
     console.error(`R process exited with code ${rStatus.code}`);
     if (stderr.trim()) console.error(stderr.trim());
     throw new Error(`R process failed with code ${rStatus.code}`);

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -133,7 +133,12 @@ async function main() {
     const killRProcess = async (): Promise<boolean> => {
       let killRequested = false;
       try {
-        rProc.kill();
+        // Use SIGKILL on POSIX for fail-fast timeout cleanup.
+        if (Deno.build.os === "windows") {
+          rProc.kill();
+        } else {
+          rProc.kill("SIGKILL");
+        }
         killRequested = true;
       } catch {
         // Continue to platform-specific hard kill below.
@@ -183,10 +188,10 @@ async function main() {
                   `frames=${stats.framesReceived}, totalOps=${stats.totalOps}, lastFrameOps=${stats.lastFrameOps}`,
               );
             }
-            const serverStderr = server.stderrSnapshot().trim();
+            const serverStderr = server.stderrSnapshot(4000).trim();
             if (serverStderr) {
               console.error("\n--- Partial server stderr ---");
-              console.error(serverStderr.slice(-4000));
+              console.error(serverStderr);
             }
           })();
           return timeoutCleanup;

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -41,6 +41,34 @@ function parseBenchTimeoutMs(): number {
   );
 }
 
+function createStreamCollector(stream: ReadableStream<Uint8Array> | null) {
+  let text = "";
+  const decoder = new TextDecoder();
+  const done = (async () => {
+    if (!stream) return;
+    const reader = stream.getReader();
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        text += decoder.decode(value, { stream: true });
+        if (text.length > 200_000) text = text.slice(-200_000);
+      }
+      text += decoder.decode();
+    } catch {
+      // Best effort collection only.
+    }
+  })();
+  return {
+    done,
+    snapshot: () => text,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // --- Main ---
 console.log(`\n${"=".repeat(60)}`);
 console.log("  jgd Benchmark Suite");
@@ -75,8 +103,10 @@ try {
     env: { ...Deno.env.toObject(), JGD_BENCH_SOCKET: socketAddr },
   });
   const rProc = rCmd.spawn();
+  const stdoutCollector = createStreamCollector(rProc.stdout);
+  const stderrCollector = createStreamCollector(rProc.stderr);
   let timeoutTriggered = false;
-  let timeoutKillPromise: Promise<boolean> | null = null;
+  let timeoutKillIssued = false;
   const killRProcess = async (): Promise<boolean> => {
     let killRequested = false;
     try {
@@ -99,37 +129,48 @@ try {
     }
     return killRequested;
   };
-  const timeoutId = setTimeout(() => {
-    timeoutTriggered = true;
-    timeoutKillPromise = killRProcess();
-  }, benchTimeoutMs);
+  let timeoutId = -1;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      timeoutTriggered = true;
+      void (async () => {
+        timeoutKillIssued = await Promise.race([
+          killRProcess(),
+          sleep(2000).then(() => false),
+        ]);
 
-  const rResult = await rProc.output();
+        const stdout = stdoutCollector.snapshot();
+        const stderr = stderrCollector.snapshot();
+        console.error(
+          `R benchmark timed out after ${benchTimeoutMs}ms` +
+            (timeoutKillIssued ? " (kill requested)" : ""),
+        );
+        if (stdout.trim()) {
+          console.error("\n--- Partial R stdout ---");
+          console.error(stdout.trim().slice(-4000));
+        }
+        if (stderr.trim()) {
+          console.error("\n--- Partial R stderr ---");
+          console.error(stderr.trim().slice(-4000));
+        }
+        reject(new Error(`R benchmark timeout after ${benchTimeoutMs}ms`));
+      })();
+    }, benchTimeoutMs);
+  });
+
+  const rStatus = await Promise.race([rProc.status, timeoutPromise]);
   clearTimeout(timeoutId);
-  const timeoutKillIssued = timeoutKillPromise
-    ? await timeoutKillPromise
-    : false;
-  const stdout = new TextDecoder().decode(rResult.stdout);
-  const stderr = new TextDecoder().decode(rResult.stderr);
+  await Promise.all([stdoutCollector.done, stderrCollector.done]);
+  const stdout = stdoutCollector.snapshot();
+  const stderr = stderrCollector.snapshot();
 
-  if (!rResult.success) {
+  if (!rStatus.success) {
     if (timeoutTriggered && timeoutKillIssued) {
-      console.error(
-        `R benchmark timed out after ${benchTimeoutMs}ms (killed process)`,
-      );
-      if (stdout.trim()) {
-        console.error("\n--- Partial R stdout ---");
-        console.error(stdout.trim().slice(-4000));
-      }
-      if (stderr.trim()) {
-        console.error("\n--- Partial R stderr ---");
-        console.error(stderr.trim().slice(-4000));
-      }
       throw new Error(`R benchmark timeout after ${benchTimeoutMs}ms`);
     }
-    console.error(`R process exited with code ${rResult.code}`);
+    console.error(`R process exited with code ${rStatus.code}`);
     if (stderr.trim()) console.error(stderr.trim());
-    throw new Error(`R process failed with code ${rResult.code}`);
+    throw new Error(`R process failed with code ${rStatus.code}`);
   }
 
   if (stderr.trim()) {

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -64,13 +64,28 @@ try {
   });
   const rProc = rCmd.spawn();
   let timedOut = false;
+  const killRProcess = async () => {
+    try {
+      rProc.kill();
+      return;
+    } catch {
+      // Fall through to platform-specific hard kill below.
+    }
+    if (Deno.build.os === "windows") {
+      try {
+        await new Deno.Command("taskkill", {
+          args: ["/PID", String(rProc.pid), "/T", "/F"],
+          stdout: "null",
+          stderr: "null",
+        }).output();
+      } catch {
+        // Best effort only.
+      }
+    }
+  };
   const timeoutId = setTimeout(() => {
     timedOut = true;
-    try {
-      rProc.kill("SIGKILL");
-    } catch {
-      // Process already exited.
-    }
+    void killRProcess();
   }, benchTimeoutMs);
 
   const rResult = await rProc.output();

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -58,6 +58,8 @@ function createStreamCollector(stream: ReadableStream<Uint8Array> | null) {
       text += decoder.decode();
     } catch {
       // Best effort collection only.
+    } finally {
+      reader.releaseLock();
     }
   })();
   return {
@@ -69,7 +71,7 @@ function createStreamCollector(stream: ReadableStream<Uint8Array> | null) {
 async function waitUpTo<T>(promise: Promise<T>, waitMs: number): Promise<void> {
   let timeoutId: number | undefined;
   await Promise.race([
-    promise.then(() => undefined),
+    promise.then(() => undefined).catch(() => undefined),
     new Promise<void>((resolve) => {
       timeoutId = setTimeout(resolve, waitMs);
     }),

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -181,6 +181,11 @@ async function main() {
                   `frames=${stats.framesReceived}, totalOps=${stats.totalOps}, lastFrameOps=${stats.lastFrameOps}`,
               );
             }
+            const serverStderr = server.stderrSnapshot().trim();
+            if (serverStderr) {
+              console.error("\n--- Partial server stderr ---");
+              console.error(serverStderr.slice(-4000));
+            }
           })();
           return timeoutCleanup;
         },

--- a/tests/bench/run_timeout_test.ts
+++ b/tests/bench/run_timeout_test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "@std/assert";
+import { settleTimeoutPath } from "./run.ts";
+
+Deno.test("settleTimeoutPath returns after collectors settle", async () => {
+  const start = Date.now();
+  await settleTimeoutPath(
+    Promise.resolve(),
+    [Promise.resolve(), Promise.resolve()],
+    20,
+  );
+  const elapsed = Date.now() - start;
+  assertEquals(elapsed < 200, true);
+});
+
+Deno.test("settleTimeoutPath bounds collector wait when collectors never close", async () => {
+  const never = new Promise<void>(() => {});
+  const start = Date.now();
+  await settleTimeoutPath(Promise.resolve(), [never, never], 50);
+  const elapsed = Date.now() - start;
+  assertEquals(elapsed >= 50, true);
+  assertEquals(elapsed < 400, true);
+});

--- a/tests/bench/timeout.ts
+++ b/tests/bench/timeout.ts
@@ -1,0 +1,18 @@
+export function raceWithTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  onTimeout: () => void | Promise<void>,
+  message: string,
+): Promise<T> {
+  let timeoutId: number | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(message));
+      void onTimeout();
+    }, timeoutMs);
+  });
+
+  return Promise.race([operation, timeoutPromise]).finally(() => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  });
+}

--- a/tests/bench/timeout.ts
+++ b/tests/bench/timeout.ts
@@ -9,9 +9,11 @@ export function raceWithTimeout<T>(
     timeoutId = setTimeout(() => {
       try {
         const timeoutResult = onTimeout();
-        void Promise.resolve(timeoutResult).catch(() => {});
-      } catch {
-        // Best effort only.
+        void Promise.resolve(timeoutResult).catch((error) => {
+          console.error("raceWithTimeout onTimeout failed:", error);
+        });
+      } catch (error) {
+        console.error("raceWithTimeout onTimeout failed:", error);
       }
       reject(new Error(message));
     }, timeoutMs);

--- a/tests/bench/timeout.ts
+++ b/tests/bench/timeout.ts
@@ -8,7 +8,9 @@ export function raceWithTimeout<T>(
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
       reject(new Error(message));
-      void onTimeout();
+      void Promise.resolve()
+        .then(() => onTimeout())
+        .catch(() => {});
     }, timeoutMs);
   });
 

--- a/tests/bench/timeout.ts
+++ b/tests/bench/timeout.ts
@@ -7,7 +7,12 @@ export function raceWithTimeout<T>(
   let timeoutId: number | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
-      void Promise.resolve(onTimeout()).catch(() => {});
+      try {
+        const timeoutResult = onTimeout();
+        void Promise.resolve(timeoutResult).catch(() => {});
+      } catch {
+        // Best effort only.
+      }
       reject(new Error(message));
     }, timeoutMs);
   });

--- a/tests/bench/timeout.ts
+++ b/tests/bench/timeout.ts
@@ -7,10 +7,8 @@ export function raceWithTimeout<T>(
   let timeoutId: number | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
+      void Promise.resolve(onTimeout()).catch(() => {});
       reject(new Error(message));
-      void Promise.resolve()
-        .then(() => onTimeout())
-        .catch(() => {});
     }, timeoutMs);
   });
 

--- a/tests/bench/timeout_test.ts
+++ b/tests/bench/timeout_test.ts
@@ -61,3 +61,26 @@ Deno.test("raceWithTimeout returns operation result before timeout", async () =>
   assertEquals(result, "ok");
   assertEquals(onTimeoutCalled, false);
 });
+
+Deno.test("raceWithTimeout sets timeout side effects before rejection is observed", async () => {
+  const operation = new Promise<string>(() => {});
+  let timeoutSideEffect = false;
+
+  const raced = raceWithTimeout(
+    operation,
+    1,
+    () => {
+      timeoutSideEffect = true;
+    },
+    "timeout",
+  );
+
+  await assertRejects(async () => {
+    try {
+      await raced;
+    } catch (error) {
+      assertEquals(timeoutSideEffect, true);
+      throw error;
+    }
+  }, Error, "timeout");
+});

--- a/tests/bench/timeout_test.ts
+++ b/tests/bench/timeout_test.ts
@@ -1,0 +1,51 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { raceWithTimeout } from "./timeout.ts";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+Deno.test("raceWithTimeout rejects immediately when timeout fires", async () => {
+  let resolveOperation: ((value: string) => void) | undefined;
+  const operation = new Promise<string>((resolve) => {
+    resolveOperation = resolve;
+  });
+
+  let onTimeoutCalled = false;
+  let onTimeoutFinished = false;
+
+  const raced = raceWithTimeout(
+    operation,
+    20,
+    async () => {
+      onTimeoutCalled = true;
+      await sleep(80);
+      onTimeoutFinished = true;
+      resolveOperation?.("finished");
+    },
+    "timeout",
+  );
+
+  await assertRejects(() => raced, Error, "timeout");
+  assertEquals(onTimeoutCalled, true);
+  assertEquals(onTimeoutFinished, false);
+
+  await sleep(120);
+  assertEquals(onTimeoutFinished, true);
+});
+
+Deno.test("raceWithTimeout returns operation result before timeout", async () => {
+  let onTimeoutCalled = false;
+
+  const result = await raceWithTimeout(
+    Promise.resolve("ok"),
+    100,
+    () => {
+      onTimeoutCalled = true;
+    },
+    "timeout",
+  );
+
+  assertEquals(result, "ok");
+  assertEquals(onTimeoutCalled, false);
+});

--- a/tests/bench/timeout_test.ts
+++ b/tests/bench/timeout_test.ts
@@ -1,10 +1,6 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { raceWithTimeout } from "./timeout.ts";
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 Deno.test("raceWithTimeout rejects immediately when timeout fires", async () => {
   let resolveOperation: ((value: string) => void) | undefined;
   const operation = new Promise<string>((resolve) => {
@@ -13,24 +9,40 @@ Deno.test("raceWithTimeout rejects immediately when timeout fires", async () => 
 
   let onTimeoutCalled = false;
   let onTimeoutFinished = false;
+  let releaseOnTimeout: (() => void) | undefined;
+  const onTimeoutBlocker = new Promise<void>((resolve) => {
+    releaseOnTimeout = resolve;
+  });
+  let markOnTimeoutStarted: (() => void) | undefined;
+  const onTimeoutStarted = new Promise<void>((resolve) => {
+    markOnTimeoutStarted = resolve;
+  });
+  let markOnTimeoutFinished: (() => void) | undefined;
+  const onTimeoutFinishedSignal = new Promise<void>((resolve) => {
+    markOnTimeoutFinished = resolve;
+  });
 
   const raced = raceWithTimeout(
     operation,
     20,
     async () => {
       onTimeoutCalled = true;
-      await sleep(80);
+      markOnTimeoutStarted?.();
+      await onTimeoutBlocker;
       onTimeoutFinished = true;
+      markOnTimeoutFinished?.();
       resolveOperation?.("finished");
     },
     "timeout",
   );
 
+  await onTimeoutStarted;
   await assertRejects(() => raced, Error, "timeout");
   assertEquals(onTimeoutCalled, true);
   assertEquals(onTimeoutFinished, false);
 
-  await sleep(120);
+  releaseOnTimeout?.();
+  await onTimeoutFinishedSignal;
   assertEquals(onTimeoutFinished, true);
 });
 


### PR DESCRIPTION
## Summary

Stabilize the Windows CI path that exposed multiple latent issues under newer runner images and Deno releases. Scope grew during investigation; the commits fall into three groups.

### 1. Native-transport (R-side): Windows named-pipe welcome handshake

Earlier runs on windows-latest failed intermittently in the native-transport E2E path (`default_transport_e2e_test.ts`, `e2e_test.ts`). Root cause was brittle handshaking: R blocked on a welcome read during `jgd()` open, so a deferred `server_info` or an early `resize` could starve the default-transport path.

- `r-pkg/src/device.c`: defer the welcome read on Windows named pipes — `C_jgd` no longer reads at open; `C_jgd_server_info` pulls the welcome lazily on first call.
- `jgd_read_welcome` now bounds its wait by an overall deadline instead of fixed attempts, preserves early normal-resize messages into `pending_w/h` so they are not dropped, and reuses the already-parsed `cJSON` for resize extraction.
- `r-pkg/src/transport.c`: distinguish timeout vs. hard error on `poll`/`select`, treating transient `EINTR`/`WSAEINTR` as a soft timeout rather than closing the transport.

### 2. Benchmark infrastructure (tests/bench)

The benchmark step was hiding failures as hangs on Windows. This rewrite makes it fail fast with useful diagnostics.

- `tests/bench/run.ts`: race `rProc.status` against a bounded timeout using `raceWithTimeout`; collect stdout/stderr via incremental stream collectors; on timeout, hard-kill the process tree (`taskkill /PID /T /F` on Windows), print partial R stdout/stderr and mock-client stats, then fail the step.
- `tests/bench/timeout.ts`, `timeout_test.ts`, `run_timeout_test.ts`: deterministic unit tests for the race + cleanup paths (no sleep-based flake).
- `tests/bench/bench-plot.R`: staged `step_log` output so CI logs show exactly how far R progressed before a hang.
- `server/tests/helpers/server.ts`: expose a `stderrSnapshot()` getter used by `run.ts` to include the server's verbose log in timeout diagnostics.
- `.github/workflows/e2e-test.yaml`: remove the benchmark step's prior `continue-on-error` so a timeout actually fails the workflow.

### 3. CI pin: Deno 2.7.11 (upstream named-pipe regression)

After fixing the R side, the Windows benchmark still hung on the second `jgd()` → `dev.off()` → `jgd()` cycle. Server stderr (via the new diagnostics) showed that after the first R session disconnects, the server never fires a second `'connection'` event on the named-pipe listener — so R's subsequent `WriteFile` blocks forever waiting for a reader Deno never installs.

The regression was introduced in Deno 2.7.12 by the native `uv_pipe_t` rewrite and reproduces with a minimal `node:net` script. See denoland/deno#33366 for details.

- `.github/workflows/e2e-test.yaml`: pin `deno-version: v2.7.11`, with a comment linking back to the upstream issue. Revisit once fixed.

### 4. CI pin: R 4.5.x (temporary)

`setup-r` is pinned to `r-version: "4.5"` in this PR because the current jgd stack is not yet compatible with the newly released R 4.6.0 (released on 2026-04-24).

- This pin is an intentional short-term stabilization measure for this PR.
- R 4.6 compatibility work will be handled in a separate follow-up PR.
- After that compatibility work lands, `setup-r` should move back to `release`.

## Testing

- `R CMD INSTALL r-pkg`
- `cd tests && deno test --allow-env --allow-net --allow-read --allow-write --allow-run default_transport_e2e_test.ts e2e_test.ts` — 8 passed
- `cd tests && deno test bench/` — bench unit tests 4 passed
- `cd tests && deno task bench` — full benchmark completes on Linux (3 frames / 4417 ops / 125 metrics)
- CI: `e2e (ubuntu-latest)` and `e2e (windows-latest)` both green on the final commit (run 24793021687 showed the Windows benchmark completing normally with the Deno pin applied).
