### PR TITLE
fix(r-pkg): avoid GetTickCount64 link failure on R 4.1 i386

### DIFF
--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -76,7 +76,9 @@ static long long jgd_now_ms(void) {
     }
 
     /* Last-resort fallback for old Windows toolchains/environments.
-       Known limitation: GetTickCount wraps every ~49.7 days (32-bit). */
+       Known limitation: GetTickCount is 32-bit and wraps every ~49.7 days.
+       PR #53 intentionally accepts this legacy limitation to keep the
+       R 4.1 i386 compatibility path simple and low-risk. */
     return (long long)GetTickCount();
 #else
     struct timespec ts;
@@ -109,7 +111,10 @@ static void jgd_read_welcome(jgd_state_t *st) {
         long long remaining_ll = deadline_ms - now_ms;
         if (remaining_ll <= 0) return;
         /* Guard wrap/inconsistency in fallback clocks without forcing
-           an early timeout; cap waits to the original timeout window. */
+           an early timeout; cap waits to the original timeout window.
+           Known limitation (intentional for legacy R 4.1 i386 path): if
+           the clock jumps backward (for example, 32-bit tick wrap), total
+           wall-clock wait here can exceed welcome_total_timeout_ms. */
         if (remaining_ll > (long long)welcome_total_timeout_ms) {
             remaining_ll = (long long)welcome_total_timeout_ms;
         }

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -99,7 +99,11 @@ static void jgd_read_welcome(jgd_state_t *st) {
        server_info is delayed or absent. */
     char buf[2048];
     const int welcome_total_timeout_ms = 2500;
-    const long long deadline_ms = jgd_now_ms() + welcome_total_timeout_ms;
+    long long now0_ms = jgd_now_ms();
+    const long long deadline_ms =
+        (now0_ms > LLONG_MAX - (long long)welcome_total_timeout_ms)
+            ? LLONG_MAX
+            : now0_ms + (long long)welcome_total_timeout_ms;
     for (;;) {
         long long now_ms = jgd_now_ms();
         long long remaining_ll = deadline_ms - now_ms;

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -76,12 +76,31 @@ static long long jgd_now_ms(void) {
     }
 
     {
-        FILETIME ft;
-        ULARGE_INTEGER ticks100ns;
-        GetSystemTimeAsFileTime(&ft);
-        ticks100ns.LowPart = ft.dwLowDateTime;
-        ticks100ns.HighPart = ft.dwHighDateTime;
-        return (long long)(ticks100ns.QuadPart / 10000ULL);
+        static volatile LONGLONG tick64 = -1;
+        DWORD tick32 = GetTickCount();
+
+        for (;;) {
+            LONGLONG prev = tick64;
+            ULONGLONG next;
+
+            if (prev < 0) {
+                next = (ULONGLONG)tick32;
+            } else {
+                DWORD prev_low = (DWORD)(prev & 0xFFFFFFFFULL);
+                ULONGLONG base = ((ULONGLONG)prev) & 0xFFFFFFFF00000000ULL;
+                next = base | (ULONGLONG)tick32;
+                if (tick32 < prev_low) {
+                    next += 0x100000000ULL;
+                }
+                if (next < (ULONGLONG)prev) {
+                    next = (ULONGLONG)prev;
+                }
+            }
+
+            if (InterlockedCompareExchange64(&tick64, (LONGLONG)next, prev) == prev) {
+                return (long long)next;
+            }
+        }
     }
 #else
     struct timespec ts;

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -11,6 +11,22 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+
+typedef ULONGLONG(WINAPI *jgd_get_tick_count64_fn)(void);
+static INIT_ONCE jgd_tick64_once = INIT_ONCE_STATIC_INIT;
+static jgd_get_tick_count64_fn jgd_get_tick_count64_cached = NULL;
+
+static BOOL CALLBACK jgd_init_get_tick_count64(PINIT_ONCE init_once, PVOID param, PVOID *ctx) {
+    (void)init_once;
+    (void)param;
+    (void)ctx;
+    HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
+    if (kernel32) {
+        jgd_get_tick_count64_cached =
+            (jgd_get_tick_count64_fn)GetProcAddress(kernel32, "GetTickCount64");
+    }
+    return TRUE;
+}
 #else
 #include <R_ext/eventloop.h>
 #endif
@@ -45,19 +61,9 @@ static int jgd_parse_resize_message(cJSON *msg, double *w, double *h, int *plot_
 
 static long long jgd_now_ms(void) {
 #ifdef _WIN32
-    typedef ULONGLONG(WINAPI *jgd_get_tick_count64_fn)(void);
-    static int tick64_resolved = 0;
-    static jgd_get_tick_count64_fn get_tick_count64 = NULL;
-    if (!tick64_resolved) {
-        HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
-        if (kernel32) {
-            get_tick_count64 =
-                (jgd_get_tick_count64_fn)GetProcAddress(kernel32, "GetTickCount64");
-        }
-        tick64_resolved = 1;
-    }
-    if (get_tick_count64) {
-        return (long long)get_tick_count64();
+    InitOnceExecuteOnce(&jgd_tick64_once, jgd_init_get_tick_count64, NULL, NULL);
+    if (jgd_get_tick_count64_cached) {
+        return (long long)jgd_get_tick_count64_cached();
     }
 
     {
@@ -80,6 +86,8 @@ static long long jgd_now_ms(void) {
         }
     }
 
+    /* Last-resort fallback for old Windows toolchains/environments.
+       Known limitation: GetTickCount wraps every ~49.7 days (32-bit). */
     return (long long)GetTickCount();
 #else
     struct timespec ts;

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -45,22 +45,23 @@ static int jgd_parse_resize_message(cJSON *msg, double *w, double *h, int *plot_
 static long long jgd_now_ms(void) {
 #ifdef _WIN32
     typedef ULONGLONG(WINAPI *jgd_get_tick_count64_fn)(void);
-    static jgd_get_tick_count64_fn get_tick_count64 = NULL;
-    static int resolved = 0;
-
-    if (!resolved) {
-        HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
-        if (kernel32) {
-            get_tick_count64 = (jgd_get_tick_count64_fn)GetProcAddress(
-                kernel32,
-                "GetTickCount64"
-            );
+    HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
+    if (kernel32) {
+        jgd_get_tick_count64_fn get_tick_count64 =
+            (jgd_get_tick_count64_fn)GetProcAddress(kernel32, "GetTickCount64");
+        if (get_tick_count64) {
+            return (long long)get_tick_count64();
         }
-        resolved = 1;
     }
 
-    if (get_tick_count64) {
-        return (long long)get_tick_count64();
+    {
+        LARGE_INTEGER freq;
+        LARGE_INTEGER counter;
+        if (QueryPerformanceFrequency(&freq) &&
+            freq.QuadPart > 0 &&
+            QueryPerformanceCounter(&counter)) {
+            return (long long)((counter.QuadPart * 1000LL) / freq.QuadPart);
+        }
     }
 
     return (long long)GetTickCount();

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -44,7 +44,26 @@ static int jgd_parse_resize_message(cJSON *msg, double *w, double *h, int *plot_
 
 static long long jgd_now_ms(void) {
 #ifdef _WIN32
-    return (long long)GetTickCount64();
+    typedef ULONGLONG(WINAPI *jgd_get_tick_count64_fn)(void);
+    static jgd_get_tick_count64_fn get_tick_count64 = NULL;
+    static int resolved = 0;
+
+    if (!resolved) {
+        HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
+        if (kernel32) {
+            get_tick_count64 = (jgd_get_tick_count64_fn)GetProcAddress(
+                kernel32,
+                "GetTickCount64"
+            );
+        }
+        resolved = 1;
+    }
+
+    if (get_tick_count64) {
+        return (long long)get_tick_count64();
+    }
+
+    return (long long)GetTickCount();
 #else
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -46,13 +46,18 @@ static int jgd_parse_resize_message(cJSON *msg, double *w, double *h, int *plot_
 static long long jgd_now_ms(void) {
 #ifdef _WIN32
     typedef ULONGLONG(WINAPI *jgd_get_tick_count64_fn)(void);
-    HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
-    if (kernel32) {
-        jgd_get_tick_count64_fn get_tick_count64 =
-            (jgd_get_tick_count64_fn)GetProcAddress(kernel32, "GetTickCount64");
-        if (get_tick_count64) {
-            return (long long)get_tick_count64();
+    static int tick64_resolved = 0;
+    static jgd_get_tick_count64_fn get_tick_count64 = NULL;
+    if (!tick64_resolved) {
+        HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
+        if (kernel32) {
+            get_tick_count64 =
+                (jgd_get_tick_count64_fn)GetProcAddress(kernel32, "GetTickCount64");
         }
+        tick64_resolved = 1;
+    }
+    if (get_tick_count64) {
+        return (long long)get_tick_count64();
     }
 
     {
@@ -75,35 +80,7 @@ static long long jgd_now_ms(void) {
         }
     }
 
-    {
-        static volatile LONGLONG tick64 = -1;
-        DWORD tick32 = GetTickCount();
-
-        for (;;) {
-            LONGLONG prev = InterlockedCompareExchange64(&tick64, 0, 0);
-            ULONGLONG next;
-
-            if (prev < 0) {
-                next = (ULONGLONG)tick32;
-            } else {
-                DWORD prev_low = (DWORD)(prev & 0xFFFFFFFFULL);
-                ULONGLONG base = ((ULONGLONG)prev) & 0xFFFFFFFF00000000ULL;
-                next = base | (ULONGLONG)tick32;
-                /* This path is a last-resort fallback (after GetTickCount64 and QPC).
-                   It assumes calls are frequent enough to observe at most one wrap. */
-                if (tick32 < prev_low) {
-                    next += 0x100000000ULL;
-                }
-                if (next < (ULONGLONG)prev) {
-                    next = (ULONGLONG)prev;
-                }
-            }
-
-            if (InterlockedCompareExchange64(&tick64, (LONGLONG)next, prev) == prev) {
-                return (long long)next;
-            }
-        }
-    }
+    return (long long)GetTickCount();
 #else
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
+#include <limits.h>
 #include <unistd.h>
 
 static int jgd_parse_resize_message(cJSON *msg, double *w, double *h, int *plot_index) {
@@ -60,11 +61,28 @@ static long long jgd_now_ms(void) {
         if (QueryPerformanceFrequency(&freq) &&
             freq.QuadPart > 0 &&
             QueryPerformanceCounter(&counter)) {
-            return (long long)((counter.QuadPart * 1000LL) / freq.QuadPart);
+            long long seconds = (long long)(counter.QuadPart / freq.QuadPart);
+            if (seconds > LLONG_MAX / 1000LL) {
+                return LLONG_MAX;
+            }
+            long long whole_ms = seconds * 1000LL;
+            long long rem = (long long)(counter.QuadPart % freq.QuadPart);
+            long long frac_ms = (long long)(((long double)rem * 1000.0L) / (long double)freq.QuadPart);
+            if (whole_ms > LLONG_MAX - frac_ms) {
+                return LLONG_MAX;
+            }
+            return whole_ms + frac_ms;
         }
     }
 
-    return (long long)GetTickCount();
+    {
+        FILETIME ft;
+        ULARGE_INTEGER ticks100ns;
+        GetSystemTimeAsFileTime(&ft);
+        ticks100ns.LowPart = ft.dwLowDateTime;
+        ticks100ns.HighPart = ft.dwHighDateTime;
+        return (long long)(ticks100ns.QuadPart / 10000ULL);
+    }
 #else
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -11,22 +11,6 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-
-typedef ULONGLONG(WINAPI *jgd_get_tick_count64_fn)(void);
-static INIT_ONCE jgd_tick64_once = INIT_ONCE_STATIC_INIT;
-static jgd_get_tick_count64_fn jgd_get_tick_count64_cached = NULL;
-
-static BOOL CALLBACK jgd_init_get_tick_count64(PINIT_ONCE init_once, PVOID param, PVOID *ctx) {
-    (void)init_once;
-    (void)param;
-    (void)ctx;
-    HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
-    if (kernel32) {
-        jgd_get_tick_count64_cached =
-            (jgd_get_tick_count64_fn)GetProcAddress(kernel32, "GetTickCount64");
-    }
-    return TRUE;
-}
 #else
 #include <R_ext/eventloop.h>
 #endif
@@ -61,9 +45,14 @@ static int jgd_parse_resize_message(cJSON *msg, double *w, double *h, int *plot_
 
 static long long jgd_now_ms(void) {
 #ifdef _WIN32
-    InitOnceExecuteOnce(&jgd_tick64_once, jgd_init_get_tick_count64, NULL, NULL);
-    if (jgd_get_tick_count64_cached) {
-        return (long long)jgd_get_tick_count64_cached();
+    typedef ULONGLONG(WINAPI *jgd_get_tick_count64_fn)(void);
+    HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
+    if (kernel32) {
+        jgd_get_tick_count64_fn get_tick_count64 =
+            (jgd_get_tick_count64_fn)GetProcAddress(kernel32, "GetTickCount64");
+        if (get_tick_count64) {
+            return (long long)get_tick_count64();
+        }
     }
 
     {

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -103,9 +103,12 @@ static void jgd_read_welcome(jgd_state_t *st) {
     for (;;) {
         long long now_ms = jgd_now_ms();
         long long remaining_ll = deadline_ms - now_ms;
-        /* Guard wrap/inconsistency in fallback clocks: this wait loop should
-           never observe a remaining time greater than the original timeout. */
-        if (remaining_ll <= 0 || remaining_ll > (long long)welcome_total_timeout_ms) return;
+        if (remaining_ll <= 0) return;
+        /* Guard wrap/inconsistency in fallback clocks without forcing
+           an early timeout; cap waits to the original timeout window. */
+        if (remaining_ll > (long long)welcome_total_timeout_ms) {
+            remaining_ll = (long long)welcome_total_timeout_ms;
+        }
         int remaining_ms = (int)remaining_ll;
 
         int n = transport_recv_line(&st->transport, buf, sizeof(buf), remaining_ms);

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -80,7 +80,7 @@ static long long jgd_now_ms(void) {
         DWORD tick32 = GetTickCount();
 
         for (;;) {
-            LONGLONG prev = tick64;
+            LONGLONG prev = InterlockedCompareExchange64(&tick64, 0, 0);
             ULONGLONG next;
 
             if (prev < 0) {
@@ -89,6 +89,8 @@ static long long jgd_now_ms(void) {
                 DWORD prev_low = (DWORD)(prev & 0xFFFFFFFFULL);
                 ULONGLONG base = ((ULONGLONG)prev) & 0xFFFFFFFF00000000ULL;
                 next = base | (ULONGLONG)tick32;
+                /* This path is a last-resort fallback (after GetTickCount64 and QPC).
+                   It assumes calls are frequent enough to observe at most one wrap. */
                 if (tick32 < prev_low) {
                     next += 0x100000000ULL;
                 }

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -102,8 +102,11 @@ static void jgd_read_welcome(jgd_state_t *st) {
     const long long deadline_ms = jgd_now_ms() + welcome_total_timeout_ms;
     for (;;) {
         long long now_ms = jgd_now_ms();
-        int remaining_ms = (int)(deadline_ms - now_ms);
-        if (remaining_ms <= 0) return;
+        long long remaining_ll = deadline_ms - now_ms;
+        /* Guard wrap/inconsistency in fallback clocks: this wait loop should
+           never observe a remaining time greater than the original timeout. */
+        if (remaining_ll <= 0 || remaining_ll > (long long)welcome_total_timeout_ms) return;
+        int remaining_ms = (int)remaining_ll;
 
         int n = transport_recv_line(&st->transport, buf, sizeof(buf), remaining_ms);
         if (n < 0) {


### PR DESCRIPTION
Follow up for #52

## Summary

Fix Windows R 4.1 (`i386`) CI build failure caused by a hard link-time dependency on `GetTickCount64` in `r-pkg/src/device.c`.

- Replace direct `GetTickCount64()` calls with runtime symbol resolution via `GetModuleHandleA("kernel32.dll") + GetProcAddress("GetTickCount64")`.
- Keep `QueryPerformanceCounter` as the primary fallback when `GetTickCount64` is unavailable.
- Keep `GetTickCount()` only as a last-resort fallback for legacy environments/toolchains.
- Avoid `InitOnceExecuteOnce` to preserve compatibility with the R 4.1 i386 Windows toolchain.
- Add defensive handling in welcome-time timeout math for fallback-clock inconsistencies.

## Failure Reference

- Actions run/job: https://github.com/grantmcdermott/jgd/actions/runs/24931580580/job/73010086310
- Error observed on 2026-04-25 in `R CMD check (windows-latest - R 4.1)`:
  - `undefined reference to 'GetTickCount64'`

## Validation

- `R CMD INSTALL r-pkg` (local Linux): passed

## Scope note

This PR is intentionally scoped to restoring CI compatibility for the legacy Windows R 4.1 i386 path. Broader clock-behavior hardening for old 32-bit environments can be addressed separately if needed.
