### PR TITLE
fix(r-pkg): Fix GC protection in replay_snapshot and C_jgd_discover

### DIFF
--- a/r-pkg/NEWS.md
+++ b/r-pkg/NEWS.md
@@ -1,6 +1,11 @@
 # Development
 
-Documentation
+## Internals
+
+- Improved GC safety in C internals by tightening `PROTECT`/`UNPROTECT`
+  handling around allocations and replay paths. (#61)
+
+## Documentation
 
 - Improved visibility of protocol specification. (#58)
 

--- a/r-pkg/src/device.c
+++ b/r-pkg/src/device.c
@@ -729,6 +729,8 @@ static void replay_snapshot(jgd_state_t *st, SEXP snap, pGEDevDesc gdd) {
         SEXP grid_ns = R_NilValue;
         SEXP grid_str = PROTECT(Rf_mkString("grid"));
         grid_ns = R_FindNamespace(grid_str);
+        if (grid_ns != R_NilValue)
+            PROTECT(grid_ns);
         UNPROTECT(1);
         if (grid_ns != R_NilValue) {
             /* Force-restore grid DL from snapshot (bypasses the
@@ -743,6 +745,7 @@ static void replay_snapshot(jgd_state_t *st, SEXP snap, pGEDevDesc gdd) {
             if (st->debug_frames)
                 REprintf("[jgd] replay_snapshot: grid.refresh() -> ops=%d err=%d\n",
                          st->page.op_count, err);
+            UNPROTECT(1);
         }
     }
 

--- a/r-pkg/src/transport.c
+++ b/r-pkg/src/transport.c
@@ -226,27 +226,29 @@ SEXP C_jgd_discover(SEXP s_path) {
     }
 
     /* Build result: list(server_name, socket_path, pid, server_info) */
-    SEXP result = PROTECT(Rf_allocVector(VECSXP, 4));
-    SEXP names = PROTECT(Rf_allocVector(STRSXP, 4));
+    int nprot = 0;
+    SEXP result = PROTECT(Rf_allocVector(VECSXP, 4)); nprot++;
+    SEXP names = PROTECT(Rf_allocVector(STRSXP, 4)); nprot++;
     SET_STRING_ELT(names, 0, Rf_mkChar("server_name"));
     SET_STRING_ELT(names, 1, Rf_mkChar("socket_path"));
     SET_STRING_ELT(names, 2, Rf_mkChar("pid"));
     SET_STRING_ELT(names, 3, Rf_mkChar("server_info"));
     Rf_setAttrib(result, R_NamesSymbol, names);
 
-    SET_VECTOR_ELT(result, 0, PROTECT(Rf_mkString(sn->valuestring)));
-    SET_VECTOR_ELT(result, 1, PROTECT(Rf_mkString(sp->valuestring)));
-    SET_VECTOR_ELT(result, 2, PROTECT(Rf_ScalarInteger(pidj->valueint)));
+    SET_VECTOR_ELT(result, 0, PROTECT(Rf_mkString(sn->valuestring))); nprot++;
+    SET_VECTOR_ELT(result, 1, PROTECT(Rf_mkString(sp->valuestring))); nprot++;
+    SET_VECTOR_ELT(result, 2, PROTECT(Rf_ScalarInteger(pidj->valueint))); nprot++;
 
     /* Build named character vector from serverInfo object */
+    SEXP info_elt = R_NilValue;
     cJSON *info = cJSON_GetObjectItem(json, "serverInfo");
     if (cJSON_IsObject(info)) {
         int np = 0;
         cJSON *child = info->child;
         while (child) { if (cJSON_IsString(child) && child->string && child->valuestring) np++; child = child->next; }
 
-        SEXP info_vec = PROTECT(Rf_allocVector(STRSXP, np));
-        SEXP info_names = PROTECT(Rf_allocVector(STRSXP, np));
+        SEXP info_vec = PROTECT(Rf_allocVector(STRSXP, np)); nprot++;
+        SEXP info_names = PROTECT(Rf_allocVector(STRSXP, np)); nprot++;
         int i = 0;
         child = info->child;
         while (child) {
@@ -258,14 +260,14 @@ SEXP C_jgd_discover(SEXP s_path) {
             child = child->next;
         }
         Rf_setAttrib(info_vec, R_NamesSymbol, info_names);
-        SET_VECTOR_ELT(result, 3, info_vec);
-        UNPROTECT(7);
+        info_elt = info_vec;
     } else {
-        SET_VECTOR_ELT(result, 3, PROTECT(Rf_allocVector(STRSXP, 0)));
-        UNPROTECT(6);
+        info_elt = PROTECT(Rf_allocVector(STRSXP, 0)); nprot++;
     }
+    SET_VECTOR_ELT(result, 3, info_elt);
 
     cJSON_Delete(json);
+    UNPROTECT(nprot);
     return result;
 }
 


### PR DESCRIPTION
## Summary
- protect `grid_ns` during replay operations that may allocate in `replay_snapshot`
- refactor `C_jgd_discover` PROTECT/UNPROTECT flow to keep protected objects alive through `cJSON_Delete`
- keep local `rchk` rerun as follow-up (not executed in this environment)

## Validation
- `R CMD build .` (in `r-pkg`) succeeds and produces `jgd_0.1.0.tar.gz`

## Notes
- This PR focuses on potential GC safety issues reported by `rchk`.
- Full `rchk` verification (https://github.com/kalibera/cran-checks) is intentionally deferred.
