### PR TITLE
test: Use headless arf for E2E tests and retire Rscript based harness

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -77,7 +77,22 @@ jobs:
           mkdir -p "$install_dir"
           case "$archive" in
             *.zip)
-              unzip -q "$archive" -d "$install_dir"
+              extract_dir="$RUNNER_TEMP/arf-extract"
+              rm -rf "$extract_dir"
+              mkdir -p "$extract_dir"
+              unzip -q "$archive" -d "$extract_dir"
+
+              source_dir="$extract_dir"
+              for _ in $(seq 1 "$strip_components"); do
+                child_count="$(find "$source_dir" -mindepth 1 -maxdepth 1 | wc -l)"
+                child_dir="$(find "$source_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+                if [ "$child_count" != "1" ] || [ -z "$child_dir" ]; then
+                  echo "Cannot strip $strip_components component(s) from $archive" >&2
+                  exit 1
+                fi
+                source_dir="$child_dir"
+              done
+              cp -a "$source_dir"/. "$install_dir"/
               ;;
             *.tar.*)
               strip_args=()

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -33,11 +33,9 @@ jobs:
           - os: ubuntu-latest
             arf-archive: arf-console-x86_64-unknown-linux-gnu.tar.xz
             arf-sha256: 7d1bdc82ac181b9a422a1274fffd390d9bda3e1d093ed617801786f8fe0821f7
-            arf-strip-components: 1
           - os: windows-latest
             arf-archive: arf-console-x86_64-pc-windows-msvc.zip
             arf-sha256: 43c3556ea68cebd58fa44ca3bb50e203a899c3a36e4c34054e54eb3a4a5b1938
-            arf-strip-components: 0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -68,44 +66,35 @@ jobs:
           version="v0.3.3"
           archive="${{ matrix.arf-archive }}"
           expected_sha256="${{ matrix.arf-sha256 }}"
-          strip_components="${{ matrix.arf-strip-components }}"
           install_dir="$RUNNER_TEMP/arf"
+          extract_dir="$RUNNER_TEMP/arf-extract"
 
           curl -fsSLO "https://github.com/eitsupi/arf/releases/download/${version}/${archive}"
           echo "${expected_sha256}  ${archive}" | sha256sum --check -
 
+          rm -rf "$install_dir" "$extract_dir"
           mkdir -p "$install_dir"
+          mkdir -p "$extract_dir"
           case "$archive" in
             *.zip)
-              extract_dir="$RUNNER_TEMP/arf-extract"
-              rm -rf "$extract_dir"
-              mkdir -p "$extract_dir"
               unzip -q "$archive" -d "$extract_dir"
-
-              source_dir="$extract_dir"
-              for _ in $(seq 1 "$strip_components"); do
-                child_count="$(find "$source_dir" -mindepth 1 -maxdepth 1 | wc -l)"
-                child_dir="$(find "$source_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
-                if [ "$child_count" != "1" ] || [ -z "$child_dir" ]; then
-                  echo "Cannot strip $strip_components component(s) from $archive" >&2
-                  exit 1
-                fi
-                source_dir="$child_dir"
-              done
-              cp -a "$source_dir"/. "$install_dir"/
               ;;
             *.tar.*)
-              strip_args=()
-              if [ "$strip_components" != "0" ]; then
-                strip_args=(--strip-components="$strip_components")
-              fi
-              tar -xf "$archive" "${strip_args[@]}" -C "$install_dir"
+              tar -xf "$archive" -C "$extract_dir"
               ;;
             *)
               echo "Unsupported arf archive type: $archive" >&2
               exit 1
               ;;
           esac
+
+          source_dir="$extract_dir"
+          child_count="$(find "$source_dir" -mindepth 1 -maxdepth 1 | wc -l)"
+          child_dir="$(find "$source_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+          if [ "$child_count" = "1" ] && [ -n "$child_dir" ]; then
+            source_dir="$child_dir"
+          fi
+          cp -a "$source_dir"/. "$install_dir"/
 
           arf_bin="$install_dir/arf"
           if [ ! -x "$arf_bin" ] && [ -x "$install_dir/arf.exe" ]; then

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -29,9 +29,15 @@ jobs:
   e2e:
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+            arf-archive: arf-console-x86_64-unknown-linux-gnu.tar.xz
+            arf-sha256: 7d1bdc82ac181b9a422a1274fffd390d9bda3e1d093ed617801786f8fe0821f7
+            arf-strip-components: 1
+          - os: windows-latest
+            arf-archive: arf-console-x86_64-pc-windows-msvc.zip
+            arf-sha256: 43c3556ea68cebd58fa44ca3bb50e203a899c3a36e4c34054e54eb3a4a5b1938
+            arf-strip-components: 0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -50,17 +56,32 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Install arf (Linux)
-        if: runner.os != 'Windows'
+      - name: Install arf
         run: |
-          curl -fsSL https://github.com/eitsupi/arf/releases/download/v0.3.3/arf-console-installer.sh | sh
-        shell: bash
+          set -euo pipefail
 
-      - name: Install arf (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          irm https://github.com/eitsupi/arf/releases/download/v0.3.3/arf-console-installer.ps1 | iex
-        shell: powershell
+          if [ "${{ runner.arch }}" != "X64" ]; then
+            echo "Unsupported arf CI architecture: ${{ runner.arch }}" >&2
+            exit 1
+          fi
+
+          version="v0.3.3"
+          archive="${{ matrix.arf-archive }}"
+          expected_sha256="${{ matrix.arf-sha256 }}"
+          strip_components="${{ matrix.arf-strip-components }}"
+          install_dir="$RUNNER_TEMP/arf"
+
+          curl -fsSLO "https://github.com/eitsupi/arf/releases/download/${version}/${archive}"
+          echo "${expected_sha256}  ${archive}" | sha256sum --check -
+
+          mkdir -p "$install_dir"
+          strip_args=()
+          if [ "$strip_components" != "0" ]; then
+            strip_args=(--strip-components="$strip_components")
+          fi
+          tar -xf "$archive" "${strip_args[@]}" -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+        shell: bash
 
       - name: Install jgd R package
         run: R CMD INSTALL r-pkg

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -75,11 +75,22 @@ jobs:
           echo "${expected_sha256}  ${archive}" | sha256sum --check -
 
           mkdir -p "$install_dir"
-          strip_args=()
-          if [ "$strip_components" != "0" ]; then
-            strip_args=(--strip-components="$strip_components")
-          fi
-          tar -xf "$archive" "${strip_args[@]}" -C "$install_dir"
+          case "$archive" in
+            *.zip)
+              unzip -q "$archive" -d "$install_dir"
+              ;;
+            *.tar.*)
+              strip_args=()
+              if [ "$strip_components" != "0" ]; then
+                strip_args=(--strip-components="$strip_components")
+              fi
+              tar -xf "$archive" "${strip_args[@]}" -C "$install_dir"
+              ;;
+            *)
+              echo "Unsupported arf archive type: $archive" >&2
+              exit 1
+              ;;
+          esac
           echo "$install_dir" >> "$GITHUB_PATH"
         shell: bash
 

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -50,6 +50,18 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Install arf (Linux)
+        if: runner.os != 'Windows'
+        run: |
+          curl -fsSL https://github.com/eitsupi/arf/releases/download/v0.3.3/arf-console-installer.sh | sh
+        shell: bash
+
+      - name: Install arf (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          irm https://github.com/eitsupi/arf/releases/download/v0.3.3/arf-console-installer.ps1 | iex
+        shell: powershell
+
       - name: Install jgd R package
         run: R CMD INSTALL r-pkg
         shell: bash

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -106,6 +106,13 @@ jobs:
               exit 1
               ;;
           esac
+
+          arf_bin="$install_dir/arf"
+          if [ ! -x "$arf_bin" ] && [ -x "$install_dir/arf.exe" ]; then
+            arf_bin="$install_dir/arf.exe"
+          fi
+          "$arf_bin" --version
+
           echo "$install_dir" >> "$GITHUB_PATH"
         shell: bash
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,16 @@
+# E2E Tests
+
+End-to-end tests for jgd. Tests that require a missing tool are automatically
+skipped.
+
+## Prerequisites
+
+- **R** with the jgd package installed:
+- **Deno** v2.x
+- **arf** v0.3.0+ — required for browser↔R interaction tests
+
+## Running Tests
+
+```sh
+deno task test
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ skipped.
 
 ## Prerequisites
 
-- **R** with the jgd package installed:
+- **R** with the jgd package installed
 - **Deno** v2.x
 - **arf** v0.3.0+ — required for browser↔R interaction tests
 

--- a/tests/arf_session_eval_error_test.ts
+++ b/tests/arf_session_eval_error_test.ts
@@ -45,3 +45,22 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "ArfSession.start: rejects accidental double start",
+  ignore: skip,
+  async fn() {
+    testLog("test start");
+    const arf = new ArfSession();
+    try {
+      await arf.start();
+      await assertRejects(
+        () => arf.start(),
+        Error,
+        "ArfSession already started",
+      );
+    } finally {
+      await arf.shutdown();
+    }
+  },
+});

--- a/tests/arf_session_eval_error_test.ts
+++ b/tests/arf_session_eval_error_test.ts
@@ -302,6 +302,10 @@ Deno.test({
       // Tight timeout: the old code would hang here until timeout because
       // the JSON was buffered but never re-examined.
       await arf.start({ timeoutMs: 500 });
+      // Shut down while the Command mock is still active so the fake pid
+      // (54321) does not reach a real `arf ipc shutdown --pid 54321` spawn,
+      // which could target an unrelated process on the CI host.
+      await arf.shutdown();
     } finally {
       Object.defineProperty(Deno, "Command", {
         value: originalCommand,
@@ -315,7 +319,6 @@ Deno.test({
         value: originalRemove,
         configurable: true,
       });
-      await arf.shutdown();
     }
   },
 });

--- a/tests/arf_session_eval_error_test.ts
+++ b/tests/arf_session_eval_error_test.ts
@@ -246,6 +246,81 @@ Deno.test({
 });
 
 Deno.test({
+  name: "ArfSession.start: drains blank line and ready JSON in same chunk",
+  async fn() {
+    const arf = new ArfSession();
+    const originalCommand = Deno.Command;
+    const originalMakeTempFile = Deno.makeTempFile;
+    const originalRemove = Deno.remove;
+    const stubLogPath = "/tmp/arf-session-drain.log";
+
+    try {
+      Object.defineProperty(Deno, "makeTempFile", {
+        value: async () => stubLogPath,
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "remove", {
+        value: async () => {},
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "Command", {
+        value: class {
+          spawn(): Deno.ChildProcess {
+            // A single read() returns a leading blank line plus the ready
+            // JSON.  The old loop processed only the first newline per
+            // read(), so the blank line was consumed and the JSON sat in
+            // the buffer until another (never-arriving) chunk.
+            const encoder = new TextEncoder();
+            let emitted = false;
+            return {
+              stdout: {
+                getReader: () => ({
+                  read: () =>
+                    emitted
+                      ? new Promise(() => {})
+                      : (emitted = true,
+                        Promise.resolve({
+                          value: encoder.encode(`\n{"pid":54321}\n`),
+                          done: false,
+                        })),
+                  releaseLock: () => {},
+                }),
+                cancel: async () => {},
+              },
+              kill: () => {},
+              status: Promise.resolve({
+                success: false,
+                code: null,
+                signal: "SIGKILL",
+              }),
+            } as unknown as Deno.ChildProcess;
+          }
+        },
+        configurable: true,
+      });
+
+      // Tight timeout: the old code would hang here until timeout because
+      // the JSON was buffered but never re-examined.
+      await arf.start({ timeoutMs: 500 });
+    } finally {
+      Object.defineProperty(Deno, "Command", {
+        value: originalCommand,
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "makeTempFile", {
+        value: originalMakeTempFile,
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "remove", {
+        value: originalRemove,
+        configurable: true,
+      });
+      await arf.shutdown();
+    }
+  },
+});
+
+Deno.test({
   name: "ArfSession.eval: throws on R evaluation error by default",
   ignore: skip,
   async fn() {

--- a/tests/arf_session_eval_error_test.ts
+++ b/tests/arf_session_eval_error_test.ts
@@ -1,0 +1,47 @@
+import { assert, assertRejects } from "@std/assert";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { testLog } from "./helpers/test_log.ts";
+
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
+
+Deno.test({
+  name: "ArfSession.eval: throws on R evaluation error by default",
+  ignore: skip,
+  async fn() {
+    testLog("test start");
+    const arf = new ArfSession();
+    try {
+      await arf.start();
+      await assertRejects(
+        () => arf.eval("stop('boom-from-test')"),
+        Error,
+        "R eval failed:",
+      );
+    } finally {
+      await arf.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name: "ArfSession.eval: throwOnRError=false returns error payload",
+  ignore: skip,
+  async fn() {
+    testLog("test start");
+    const arf = new ArfSession();
+    try {
+      await arf.start();
+      const result = await arf.eval("stop('boom-from-test')", 30_000, {
+        throwOnRError: false,
+      });
+      assert(
+        result.error !== null &&
+          result.error.includes("boom-from-test"),
+        `Expected result.error to include boom-from-test, got: ${result.error}`,
+      );
+    } finally {
+      await arf.shutdown();
+    }
+  },
+});

--- a/tests/arf_session_eval_error_test.ts
+++ b/tests/arf_session_eval_error_test.ts
@@ -143,6 +143,109 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "ArfSession.shutdown: kills headless process and cleans temp log when IPC shutdown spawn fails",
+  async fn() {
+    const arf = new ArfSession();
+    const originalCommand = Deno.Command;
+    const originalMakeTempFile = Deno.makeTempFile;
+    const originalRemove = Deno.remove;
+    const killCalls: string[] = [];
+    const removedPaths: string[] = [];
+    const stubLogPath = "/tmp/arf-session-shutdown-fallback.log";
+
+    try {
+      Object.defineProperty(Deno, "makeTempFile", {
+        value: async () => stubLogPath,
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "remove", {
+        value: async (path: string | URL) => {
+          removedPaths.push(String(path));
+        },
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "Command", {
+        value: class {
+          #args: string[];
+          constructor(_cmd: string, opts: { args?: string[] }) {
+            this.#args = opts.args ?? [];
+          }
+          spawn(): Deno.ChildProcess {
+            if (this.#args.includes("shutdown")) {
+              // Simulate `arf ipc shutdown` failing to spawn (e.g. arf
+              // binary disappeared mid-test). #shutdownByIpc must surface
+              // this without leaving the headless child running.
+              throw new Error("arf ipc shutdown spawn failed");
+            }
+            // `arf headless` mock: emit a valid ready JSON line, accept a
+            // kill() call, and resolve its status so shutdown() can await it.
+            const encoder = new TextEncoder();
+            let emitted = false;
+            return {
+              stdout: {
+                getReader: () => ({
+                  read: () =>
+                    emitted
+                      ? Promise.resolve({ value: undefined, done: true })
+                      : (emitted = true,
+                        Promise.resolve({
+                          value: encoder.encode(`{"pid":12345}\n`),
+                          done: false,
+                        })),
+                  releaseLock: () => {},
+                }),
+                cancel: async () => {},
+              },
+              kill: (signal: string) => {
+                killCalls.push(signal);
+              },
+              status: Promise.resolve({
+                success: false,
+                code: null,
+                signal: "SIGKILL",
+              }),
+            } as unknown as Deno.ChildProcess;
+          }
+        },
+        configurable: true,
+      });
+
+      await arf.start();
+      // Should not throw: shutdown swallows the IPC spawn failure, but the
+      // headless process MUST still be killed and the temp log MUST be
+      // cleaned up so neither leaks past this call.
+      await arf.shutdown();
+
+      assert(
+        killCalls.includes("SIGKILL"),
+        `Expected headless process to receive SIGKILL when IPC shutdown ` +
+          `spawn fails, got kill signals: ${killCalls.join(", ") || "(none)"}`,
+      );
+      assert(
+        removedPaths.includes(stubLogPath),
+        `Expected temp log cleanup, removed: ${
+          removedPaths.join(", ") || "(none)"
+        }`,
+      );
+    } finally {
+      Object.defineProperty(Deno, "Command", {
+        value: originalCommand,
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "makeTempFile", {
+        value: originalMakeTempFile,
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "remove", {
+        value: originalRemove,
+        configurable: true,
+      });
+    }
+  },
+});
+
+Deno.test({
   name: "ArfSession.eval: throws on R evaluation error by default",
   ignore: skip,
   async fn() {

--- a/tests/arf_session_eval_error_test.ts
+++ b/tests/arf_session_eval_error_test.ts
@@ -11,6 +11,11 @@ Deno.test({
     const arf = new ArfSession();
     const originalMakeTempFile = Deno.makeTempFile;
     const originalCommand = Deno.Command;
+    const originalRemove = Deno.remove;
+    // Stub Deno.remove so the temp-log cleanup path does not touch the
+    // real filesystem if a developer happens to have a file at the
+    // hard-coded mock path on their machine.
+    const removedPaths: string[] = [];
     try {
       Object.defineProperty(Deno, "makeTempFile", {
         value: async () => {
@@ -24,8 +29,9 @@ Deno.test({
         "temp log unavailable",
       );
 
+      const stubLogPath = "/tmp/arf-session-test.log";
       Object.defineProperty(Deno, "makeTempFile", {
-        value: async () => "/tmp/arf-session-test.log",
+        value: async () => stubLogPath,
         configurable: true,
       });
       Object.defineProperty(Deno, "Command", {
@@ -36,10 +42,22 @@ Deno.test({
         },
         configurable: true,
       });
+      Object.defineProperty(Deno, "remove", {
+        value: async (path: string | URL) => {
+          removedPaths.push(String(path));
+        },
+        configurable: true,
+      });
       await assertRejects(
         () => arf.start(),
         Error,
         "spawn reached after temp log failure",
+      );
+      assert(
+        removedPaths.includes(stubLogPath),
+        `Expected stub log cleanup to be attempted, removed: ${
+          removedPaths.join(", ")
+        }`,
       );
     } finally {
       Object.defineProperty(Deno, "makeTempFile", {
@@ -48,6 +66,10 @@ Deno.test({
       });
       Object.defineProperty(Deno, "Command", {
         value: originalCommand,
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "remove", {
+        value: originalRemove,
         configurable: true,
       });
       await arf.shutdown();

--- a/tests/arf_session_eval_error_test.ts
+++ b/tests/arf_session_eval_error_test.ts
@@ -64,3 +64,23 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "ArfSession.start: rejects concurrent start calls",
+  ignore: skip,
+  async fn() {
+    testLog("test start");
+    const arf = new ArfSession();
+    try {
+      const start = arf.start();
+      await assertRejects(
+        () => arf.start(),
+        Error,
+        "ArfSession already started",
+      );
+      await start;
+    } finally {
+      await arf.shutdown();
+    }
+  },
+});

--- a/tests/arf_session_eval_error_test.ts
+++ b/tests/arf_session_eval_error_test.ts
@@ -6,6 +6,121 @@ const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
 
 Deno.test({
+  name: "ArfSession.start: resets starting state after temp log creation fails",
+  async fn() {
+    const arf = new ArfSession();
+    const originalMakeTempFile = Deno.makeTempFile;
+    const originalCommand = Deno.Command;
+    try {
+      Object.defineProperty(Deno, "makeTempFile", {
+        value: async () => {
+          throw new Error("temp log unavailable");
+        },
+        configurable: true,
+      });
+      await assertRejects(
+        () => arf.start(),
+        Error,
+        "temp log unavailable",
+      );
+
+      Object.defineProperty(Deno, "makeTempFile", {
+        value: async () => "/tmp/arf-session-test.log",
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "Command", {
+        value: class {
+          spawn(): Deno.ChildProcess {
+            throw new Error("spawn reached after temp log failure");
+          }
+        },
+        configurable: true,
+      });
+      await assertRejects(
+        () => arf.start(),
+        Error,
+        "spawn reached after temp log failure",
+      );
+    } finally {
+      Object.defineProperty(Deno, "makeTempFile", {
+        value: originalMakeTempFile,
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "Command", {
+        value: originalCommand,
+        configurable: true,
+      });
+      await arf.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "ArfSession.start: preserves caller-provided log file after startup failure",
+  async fn() {
+    const arf = new ArfSession();
+    const originalCommand = Deno.Command;
+    const originalRemove = Deno.remove;
+    const callerLogFile = "/tmp/arf-session-caller.log";
+    const removedPaths: string[] = [];
+
+    try {
+      Object.defineProperty(Deno, "Command", {
+        value: class {
+          spawn(): Deno.ChildProcess {
+            return {
+              stdout: {
+                getReader: () => ({
+                  read: () => new Promise(() => {}),
+                  releaseLock: () => {},
+                }),
+                cancel: async () => {},
+              },
+              kill: () => {},
+              status: Promise.resolve({
+                success: false,
+                code: null,
+                signal: "SIGKILL",
+              }),
+            } as unknown as Deno.ChildProcess;
+          }
+        },
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "remove", {
+        value: async (path: string | URL) => {
+          removedPaths.push(String(path));
+        },
+        configurable: true,
+      });
+
+      await assertRejects(
+        () => arf.start({ logFile: callerLogFile, timeoutMs: 1 }),
+        Error,
+        "startup timed out",
+      );
+      assert(
+        !removedPaths.includes(callerLogFile),
+        `Expected caller log to be preserved, removed: ${
+          removedPaths.join(", ")
+        }`,
+      );
+    } finally {
+      Object.defineProperty(Deno, "Command", {
+        value: originalCommand,
+        configurable: true,
+      });
+      Object.defineProperty(Deno, "remove", {
+        value: originalRemove,
+        configurable: true,
+      });
+      await arf.shutdown();
+    }
+  },
+});
+
+Deno.test({
   name: "ArfSession.eval: throws on R evaluation error by default",
   ignore: skip,
   async fn() {

--- a/tests/bench/mock-metrics-client.ts
+++ b/tests/bench/mock-metrics-client.ts
@@ -144,7 +144,9 @@ export class MockMetricsClient {
 if (import.meta.main) {
   const url = Deno.args[0];
   if (!url) {
-    console.error("Usage: deno run --allow-net mock-metrics-client.ts <ws_url>");
+    console.error(
+      "Usage: deno run --allow-net mock-metrics-client.ts <ws_url>",
+    );
     Deno.exit(1);
   }
 

--- a/tests/bench/run_timeout_test.ts
+++ b/tests/bench/run_timeout_test.ts
@@ -1,7 +1,9 @@
 import { assertEquals } from "@std/assert";
 import { settleTimeoutPath } from "./run.ts";
+import { testLog } from "../helpers/test_log.ts";
 
 Deno.test("settleTimeoutPath returns after collectors settle", async () => {
+  testLog("test start");
   const start = Date.now();
   await settleTimeoutPath(
     Promise.resolve(),
@@ -13,6 +15,7 @@ Deno.test("settleTimeoutPath returns after collectors settle", async () => {
 });
 
 Deno.test("settleTimeoutPath bounds collector wait when collectors never close", async () => {
+  testLog("test start");
   const never = new Promise<void>(() => {});
   const start = Date.now();
   await settleTimeoutPath(Promise.resolve(), [never, never], 50);

--- a/tests/bench/timeout_test.ts
+++ b/tests/bench/timeout_test.ts
@@ -75,12 +75,16 @@ Deno.test("raceWithTimeout sets timeout side effects before rejection is observe
     "timeout",
   );
 
-  await assertRejects(async () => {
-    try {
-      await raced;
-    } catch (error) {
-      assertEquals(timeoutSideEffect, true);
-      throw error;
-    }
-  }, Error, "timeout");
+  await assertRejects(
+    async () => {
+      try {
+        await raced;
+      } catch (error) {
+        assertEquals(timeoutSideEffect, true);
+        throw error;
+      }
+    },
+    Error,
+    "timeout",
+  );
 });

--- a/tests/bench/timeout_test.ts
+++ b/tests/bench/timeout_test.ts
@@ -1,7 +1,9 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { raceWithTimeout } from "./timeout.ts";
+import { testLog } from "../helpers/test_log.ts";
 
 Deno.test("raceWithTimeout rejects immediately when timeout fires", async () => {
+  testLog("test start");
   let resolveOperation: ((value: string) => void) | undefined;
   const operation = new Promise<string>((resolve) => {
     resolveOperation = resolve;
@@ -47,6 +49,7 @@ Deno.test("raceWithTimeout rejects immediately when timeout fires", async () => 
 });
 
 Deno.test("raceWithTimeout returns operation result before timeout", async () => {
+  testLog("test start");
   let onTimeoutCalled = false;
 
   const result = await raceWithTimeout(
@@ -63,6 +66,7 @@ Deno.test("raceWithTimeout returns operation result before timeout", async () =>
 });
 
 Deno.test("raceWithTimeout sets timeout side effects before rejection is observed", async () => {
+  testLog("test start");
   const operation = new Promise<string>(() => {});
   let timeoutSideEffect = false;
 

--- a/tests/default_transport_e2e_test.ts
+++ b/tests/default_transport_e2e_test.ts
@@ -50,7 +50,7 @@ Deno.test({
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await t.step("plot.new + rect produces frame with rect op", async () => {
         const result = await arf.eval(
@@ -93,7 +93,7 @@ Deno.test({
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await t.step(
         "dev.off flushes frame and sends close message",

--- a/tests/default_transport_e2e_test.ts
+++ b/tests/default_transport_e2e_test.ts
@@ -8,6 +8,7 @@
 import { assert } from "@std/assert";
 import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
+import { testLog } from "./helpers/test_log.ts";
 import type {
   CloseMessage,
   FrameMessage,
@@ -24,6 +25,7 @@ Deno.test({
   name: "E2E default transport: basic frame relay",
   ignore: skip,
   async fn(t) {
+    testLog("test start");
     // No { tcp: true } — uses Unix socket on POSIX, named pipe on Windows.
     const server = new TestServer();
     const browser = new AutoMetricsBrowserClient();
@@ -83,6 +85,7 @@ Deno.test({
   name: "E2E default transport: device close",
   ignore: skip,
   async fn(t) {
+    testLog("test start");
     const server = new TestServer();
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/default_transport_e2e_test.ts
+++ b/tests/default_transport_e2e_test.ts
@@ -51,9 +51,6 @@ Deno.test({
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await t.step("plot.new + rect produces frame with rect op", async () => {
         const result = await arf.eval(
           `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96); plot.new(); rect(0, 0, 1, 1); dev.off()`,
@@ -95,9 +92,6 @@ Deno.test({
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await t.step(
         "dev.off flushes frame and sends close message",
         async () => {

--- a/tests/default_transport_e2e_test.ts
+++ b/tests/default_transport_e2e_test.ts
@@ -13,18 +13,21 @@ import type {
   FrameMessage,
 } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { checkRAvailable, runR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 const isWindows = Deno.build.os === "windows";
 
 Deno.test({
   name: "E2E default transport: basic frame relay",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn(t) {
     // No { tcp: true } — uses Unix socket on POSIX, named pipe on Windows.
     const server = new TestServer();
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -43,17 +46,18 @@ Deno.test({
         }
       });
 
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
       await delay(200);
 
       await t.step("plot.new + rect produces frame with rect op", async () => {
-        const result = await runR(
-          'jgd(width=8, height=6, dpi=96); plot.new(); rect(0, 0, 1, 1); dev.off()',
-          server.socketPath,
+        const result = await arf.eval(
+          `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96); plot.new(); rect(0, 0, 1, 1); dev.off()`,
         );
-        if (!result.success) {
-          throw new Error(`R failed (exit ${result.exitCode}): ${result.stderr}`);
+        if (result.error) {
+          throw new Error(`R eval failed: ${result.error}`);
         }
 
         const frame = await browser.waitForType<FrameMessage>("frame");
@@ -67,6 +71,7 @@ Deno.test({
       });
     } finally {
       browser.close();
+      await arf.shutdown();
       await delay(100);
       await server.shutdown();
       server.cleanup();
@@ -76,32 +81,38 @@ Deno.test({
 
 Deno.test({
   name: "E2E default transport: device close",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn(t) {
     const server = new TestServer();
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
       await delay(200);
 
-      await t.step("dev.off flushes frame and sends close message", async () => {
-        const result = await runR(
-          'jgd(width=8, height=6, dpi=96); plot.new(); rect(0, 0, 1, 1); dev.off()',
-          server.socketPath,
-        );
-        if (!result.success) {
-          throw new Error(`R failed (exit ${result.exitCode}): ${result.stderr}`);
-        }
+      await t.step(
+        "dev.off flushes frame and sends close message",
+        async () => {
+          const result = await arf.eval(
+            `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96); plot.new(); rect(0, 0, 1, 1); dev.off()`,
+          );
+          if (result.error) {
+            throw new Error(`R eval failed: ${result.error}`);
+          }
 
-        await browser.waitForType<FrameMessage>("frame");
-        const closeMsg = await browser.waitForType<CloseMessage>("close");
-        assert(closeMsg.type === "close", "Expected close message");
-      });
+          await browser.waitForType<FrameMessage>("frame");
+          const closeMsg = await browser.waitForType<CloseMessage>("close");
+          assert(closeMsg.type === "close", "Expected close message");
+        },
+      );
     } finally {
       browser.close();
+      await arf.shutdown();
       await delay(100);
       await server.shutdown();
       server.cleanup();

--- a/tests/default_transport_e2e_test.ts
+++ b/tests/default_transport_e2e_test.ts
@@ -13,11 +13,11 @@ import type {
   FrameMessage,
 } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 const isWindows = Deno.build.os === "windows";
 
 Deno.test({

--- a/tests/deno.json
+++ b/tests/deno.json
@@ -10,7 +10,8 @@
     // --allow-run and --allow-net are unrestricted: E2E tests spawn R,
     // Rscript, and deno subprocesses, and Astral launches a Chromium binary
     // from a versioned cache path that cannot be allow-listed statically.
-    "test": "deno test --fail-fast --allow-net --allow-read --allow-write --allow-env --allow-run .",
+    "test": "deno test --allow-net --allow-read --allow-write --allow-env --allow-run .",
+    "test:fail-fast": "deno test --fail-fast --allow-net --allow-read --allow-write --allow-env --allow-run .",
     "bench": "deno run --allow-all bench/run.ts"
   }
 }

--- a/tests/deno.json
+++ b/tests/deno.json
@@ -10,7 +10,7 @@
     // --allow-run and --allow-net are unrestricted: E2E tests spawn R,
     // Rscript, and deno subprocesses, and Astral launches a Chromium binary
     // from a versioned cache path that cannot be allow-listed statically.
-    "test": "deno test --allow-net --allow-read --allow-write --allow-env --allow-run .",
+    "test": "deno test --fail-fast --allow-net --allow-read --allow-write --allow-env --allow-run .",
     "bench": "deno run --allow-all bench/run.ts"
   }
 }

--- a/tests/e2e_test.ts
+++ b/tests/e2e_test.ts
@@ -10,31 +10,35 @@ import type {
   FrameMessage,
 } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { checkRAvailable, runR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-// Pre-check: skip all tests if R + jgd are not available
-const rAvailable = await checkRAvailable();
+// Pre-check: skip all tests if R + jgd + arf are not available
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
   name: "E2E: basic frame relay",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn(t) {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
       await delay(200);
 
       await t.step("plot.new + rect produces frame with rect op", async () => {
-        const result = await runR(
-          'jgd(width=8, height=6, dpi=96); plot.new(); rect(0, 0, 1, 1); dev.off()',
-          server.socketPath,
+        const result = await arf.eval(
+          `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96); plot.new(); rect(0, 0, 1, 1); dev.off()`,
         );
-        if (!result.success) {
-          throw new Error(`R failed (exit ${result.exitCode}): ${result.stderr}`);
+        if (result.error) {
+          throw new Error(`R eval failed: ${result.error}`);
         }
 
         const frame = await browser.waitForType<FrameMessage>("frame");
@@ -49,6 +53,7 @@ Deno.test({
       });
     } finally {
       browser.close();
+      await arf.shutdown();
       await delay(100);
       await server.shutdown();
       server.cleanup();
@@ -58,42 +63,48 @@ Deno.test({
 
 Deno.test({
   name: "E2E: text metrics round-trip",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn(t) {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
       await delay(200);
 
-      await t.step("text() triggers metrics requests and produces text op", async () => {
-        const result = await runR(
-          'jgd(width=8, height=6, dpi=96); plot.new(); text(0.5, 0.5, "Hello"); dev.off()',
-          server.socketPath,
-        );
-        if (!result.success) {
-          throw new Error(`R failed (exit ${result.exitCode}): ${result.stderr}`);
-        }
+      await t.step(
+        "text() triggers metrics requests and produces text op",
+        async () => {
+          const result = await arf.eval(
+            `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96); plot.new(); text(0.5, 0.5, "Hello"); dev.off()`,
+          );
+          if (result.error) {
+            throw new Error(`R eval failed: ${result.error}`);
+          }
 
-        const frame = await browser.waitForType<FrameMessage>("frame");
-        assert(frame.plot.ops.length > 0, "Frame should have ops");
+          const frame = await browser.waitForType<FrameMessage>("frame");
+          assert(frame.plot.ops.length > 0, "Frame should have ops");
 
-        const ops = frame.plot.ops as Array<Record<string, unknown>>;
-        const textOps = ops.filter((op) => op.op === "text");
-        assert(textOps.length > 0, "Frame should contain a text op");
+          const ops = frame.plot.ops as Array<Record<string, unknown>>;
+          const textOps = ops.filter((op) => op.op === "text");
+          assert(textOps.length > 0, "Frame should contain a text op");
 
-        assert(
-          browser.metricsRequests.length > 0,
-          "Should have received metrics requests for text rendering",
-        );
+          assert(
+            browser.metricsRequests.length > 0,
+            "Should have received metrics requests for text rendering",
+          );
 
-        await browser.waitForType<CloseMessage>("close");
-      });
+          await browser.waitForType<CloseMessage>("close");
+        },
+      );
     } finally {
       browser.close();
+      await arf.shutdown();
       await delay(100);
       await server.shutdown();
       server.cleanup();
@@ -103,39 +114,45 @@ Deno.test({
 
 Deno.test({
   name: "E2E: realistic plot",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn(t) {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
       await delay(200);
 
-      await t.step("plot(1:5) produces frame with multiple op types", async () => {
-        const result = await runR(
-          'jgd(width=8, height=6, dpi=96); plot(1:5, 1:5, main="E2E"); dev.off()',
-          server.socketPath,
-        );
-        if (!result.success) {
-          throw new Error(`R failed (exit ${result.exitCode}): ${result.stderr}`);
-        }
+      await t.step(
+        "plot(1:5) produces frame with multiple op types",
+        async () => {
+          const result = await arf.eval(
+            `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96); plot(1:5, 1:5, main="E2E"); dev.off()`,
+          );
+          if (result.error) {
+            throw new Error(`R eval failed: ${result.error}`);
+          }
 
-        const frame = await browser.waitForType<FrameMessage>("frame");
-        const ops = frame.plot.ops as Array<Record<string, unknown>>;
-        const opTypes = new Set(ops.map((op) => op.op));
+          const frame = await browser.waitForType<FrameMessage>("frame");
+          const ops = frame.plot.ops as Array<Record<string, unknown>>;
+          const opTypes = new Set(ops.map((op) => op.op));
 
-        // A realistic plot should contain at least clip, line, and text ops
-        assert(opTypes.has("clip"), "Plot should have clip ops");
-        assert(opTypes.has("line"), "Plot should have line ops");
-        assert(opTypes.has("text"), "Plot should have text ops");
+          // A realistic plot should contain at least clip, line, and text ops
+          assert(opTypes.has("clip"), "Plot should have clip ops");
+          assert(opTypes.has("line"), "Plot should have line ops");
+          assert(opTypes.has("text"), "Plot should have text ops");
 
-        await browser.waitForType<CloseMessage>("close");
-      });
+          await browser.waitForType<CloseMessage>("close");
+        },
+      );
     } finally {
       browser.close();
+      await arf.shutdown();
       await delay(100);
       await server.shutdown();
       server.cleanup();
@@ -148,27 +165,38 @@ Deno.test({
 // character vectors (atomic vectors always map to JSON arrays, not objects).
 // Converting to a list preserves the key-value structure in JSON output.
 const SERVER_INFO_R_CODE =
-  'jgd(width=4, height=3, dpi=72); info = jgd_server_info(); invisible(dev.off()); info$server_info = as.list(info$server_info); cat(jsonlite::toJSON(info, auto_unbox=TRUE))';
+  "jgd(width=4, height=3, dpi=72); info = jgd_server_info(); invisible(dev.off()); info$server_info = as.list(info$server_info); cat(jsonlite::toJSON(info, auto_unbox=TRUE))";
 
-for (const { label, opts, expectedTransport } of [
-  { label: "TCP", opts: { tcp: true }, expectedTransport: "tcp" },
-  { label: "native", opts: {}, expectedTransport: Deno.build.os === "windows" ? "npipe" : "unix" },
-] as const) {
+for (
+  const { label, opts, expectedTransport } of [
+    { label: "TCP", opts: { tcp: true }, expectedTransport: "tcp" },
+    {
+      label: "native",
+      opts: {},
+      expectedTransport: Deno.build.os === "windows" ? "npipe" : "unix",
+    },
+  ] as const
+) {
   Deno.test({
     name: `E2E: jgd_server_info() over ${label} transport`,
-    ignore: !rAvailable,
+    ignore: skip,
     async fn() {
       const server = new TestServer(opts);
+      const arf = new ArfSession();
 
       try {
         await server.start();
+        await arf.start();
+        const socketAddr = toRSocketAddress(server.socketPath);
 
-        const result = await runR(SERVER_INFO_R_CODE, server.socketPath);
-        if (!result.success) {
-          throw new Error(`R failed (exit ${result.exitCode}): ${result.stderr}`);
+        const result = await arf.eval(
+          `options(jgd.socket = "${socketAddr}"); library(jgd); ${SERVER_INFO_R_CODE}`,
+        );
+        if (result.error) {
+          throw new Error(`R eval failed: ${result.error}`);
         }
 
-        const info = JSON.parse(result.stdout);
+        const info = JSON.parse(result.stdout!);
         assertEquals(info.server_name, "jgd-http-server");
         assertEquals(info.protocol_version, 1);
         assertEquals(
@@ -177,6 +205,7 @@ for (const { label, opts, expectedTransport } of [
         );
         assertEquals(info.transport, expectedTransport);
       } finally {
+        await arf.shutdown();
         await server.shutdown();
         server.cleanup();
       }
@@ -186,37 +215,51 @@ for (const { label, opts, expectedTransport } of [
 
 Deno.test({
   name: "E2E: device dimensions",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn(t) {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
       await delay(200);
 
-      await t.step("custom device dimensions are reported in frame", async () => {
-        const result = await runR(
-          'jgd(width=5, height=4, dpi=72); plot.new(); rect(0, 0, 1, 1); dev.off()',
-          server.socketPath,
-        );
-        if (!result.success) {
-          throw new Error(`R failed (exit ${result.exitCode}): ${result.stderr}`);
-        }
+      await t.step(
+        "custom device dimensions are reported in frame",
+        async () => {
+          const result = await arf.eval(
+            `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=5, height=4, dpi=72); plot.new(); rect(0, 0, 1, 1); dev.off()`,
+          );
+          if (result.error) {
+            throw new Error(`R eval failed: ${result.error}`);
+          }
 
-        const frame = await browser.waitForType<FrameMessage>("frame");
-        const device = frame.plot.device as Record<string, number>;
-        // Device dimensions are in pixels (width_inches * dpi)
-        assertEquals(device.width, 5 * 72, "Device width should be 5in * 72dpi = 360px");
-        assertEquals(device.height, 4 * 72, "Device height should be 4in * 72dpi = 288px");
-        assertEquals(device.dpi, 72, "Device DPI should be 72");
+          const frame = await browser.waitForType<FrameMessage>("frame");
+          const device = frame.plot.device as Record<string, number>;
+          // Device dimensions are in pixels (width_inches * dpi)
+          assertEquals(
+            device.width,
+            5 * 72,
+            "Device width should be 5in * 72dpi = 360px",
+          );
+          assertEquals(
+            device.height,
+            4 * 72,
+            "Device height should be 4in * 72dpi = 288px",
+          );
+          assertEquals(device.dpi, 72, "Device DPI should be 72");
 
-        await browser.waitForType<CloseMessage>("close");
-      });
+          await browser.waitForType<CloseMessage>("close");
+        },
+      );
     } finally {
       browser.close();
+      await arf.shutdown();
       await delay(100);
       await server.shutdown();
       server.cleanup();

--- a/tests/e2e_test.ts
+++ b/tests/e2e_test.ts
@@ -5,6 +5,7 @@
 import { assert, assertEquals } from "@std/assert";
 import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
+import { testLog } from "./helpers/test_log.ts";
 import type {
   CloseMessage,
   FrameMessage,
@@ -21,6 +22,7 @@ Deno.test({
   name: "E2E: basic frame relay",
   ignore: skip,
   async fn(t) {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -65,6 +67,7 @@ Deno.test({
   name: "E2E: text metrics round-trip",
   ignore: skip,
   async fn(t) {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -116,6 +119,7 @@ Deno.test({
   name: "E2E: realistic plot",
   ignore: skip,
   async fn(t) {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -181,6 +185,7 @@ for (
     name: `E2E: jgd_server_info() over ${label} transport`,
     ignore: skip,
     async fn() {
+      testLog("test start");
       const server = new TestServer(opts);
       const arf = new ArfSession();
 
@@ -217,6 +222,7 @@ Deno.test({
   name: "E2E: device dimensions",
   ignore: skip,
   async fn(t) {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/e2e_test.ts
+++ b/tests/e2e_test.ts
@@ -32,9 +32,6 @@ Deno.test({
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await t.step("plot.new + rect produces frame with rect op", async () => {
         const result = await arf.eval(
           `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96); plot.new(); rect(0, 0, 1, 1); dev.off()`,
@@ -77,9 +74,6 @@ Deno.test({
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await t.step(
         "text() triggers metrics requests and produces text op",
         async () => {
@@ -129,9 +123,6 @@ Deno.test({
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await t.step(
         "plot(1:5) produces frame with multiple op types",
         async () => {
@@ -244,9 +235,6 @@ Deno.test({
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await t.step(
         "custom device dimensions are reported in frame",
         async () => {

--- a/tests/e2e_test.ts
+++ b/tests/e2e_test.ts
@@ -10,12 +10,12 @@ import type {
   FrameMessage,
 } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
 // Pre-check: skip all tests if R + jgd + arf are not available
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name: "E2E: basic frame relay",

--- a/tests/e2e_test.ts
+++ b/tests/e2e_test.ts
@@ -31,7 +31,7 @@ Deno.test({
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await t.step("plot.new + rect produces frame with rect op", async () => {
         const result = await arf.eval(
@@ -75,7 +75,7 @@ Deno.test({
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await t.step(
         "text() triggers metrics requests and produces text op",
@@ -126,7 +126,7 @@ Deno.test({
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await t.step(
         "plot(1:5) produces frame with multiple op types",
@@ -227,7 +227,7 @@ Deno.test({
       const socketAddr = toRSocketAddress(server.socketPath);
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await t.step(
         "custom device dimensions are reported in frame",

--- a/tests/e2e_test.ts
+++ b/tests/e2e_test.ts
@@ -190,17 +190,25 @@ for (
       const arf = new ArfSession();
 
       try {
+        testLog(`${label}: server.start begin`);
         await server.start();
-        await arf.start();
+        testLog(`${label}: server.start done`);
+        testLog(`${label}: arf.start begin`);
+        await arf.start({ timeoutMs: 15_000 });
+        testLog(`${label}: arf.start done`);
         const socketAddr = toRSocketAddress(server.socketPath);
 
+        testLog(`${label}: jgd_server_info eval begin`);
         const result = await arf.eval(
           `options(jgd.socket = "${socketAddr}"); library(jgd); ${SERVER_INFO_R_CODE}`,
+          15_000,
         );
+        testLog(`${label}: jgd_server_info eval done`);
         if (result.error) {
           throw new Error(`R eval failed: ${result.error}`);
         }
 
+        testLog(`${label}: parse/assert begin`);
         const info = JSON.parse(result.stdout!);
         assertEquals(info.server_name, "jgd-http-server");
         assertEquals(info.protocol_version, 1);
@@ -209,10 +217,14 @@ for (
           `http://127.0.0.1:${server.httpPort}/`,
         );
         assertEquals(info.transport, expectedTransport);
+        testLog(`${label}: parse/assert done`);
       } finally {
+        testLog(`${label}: cleanup arf shutdown begin`);
         await arf.shutdown();
+        testLog(`${label}: cleanup server shutdown begin`);
         await server.shutdown();
         server.cleanup();
+        testLog(`${label}: cleanup done`);
       }
     },
   });

--- a/tests/gc_ext_e2e_test.ts
+++ b/tests/gc_ext_e2e_test.ts
@@ -10,16 +10,19 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
   name: "E2E: jgd_ext() embeds gc.ext in frame ops",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -27,47 +30,43 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      // Setup: load jgd with socket
+      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // R code: set ext, draw a plot, verify ext is embedded in ops
-      const rCode = [
-        'jgd(width=8, height=6, dpi=96)',
-        'jgd_ext(\'{"blendMode":"multiply","opacity":0.5}\')',
-        'plot(1:3)',
-        'for (i in 1:100) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-      ].join("; ");
+      await arf.eval(
+        "jgd(width=8, height=6, dpi=96); " +
+          'jgd_ext(\'{"blendMode":"multiply","opacity":0.5}\'); ' +
+          "plot(1:3)",
+      );
 
-      const r = startR(rCode, server.socketPath);
+      const frame = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame.plot.ops.length > 0, "Frame should have ops");
 
-      try {
-        const frame = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame.plot.ops.length > 0, "Frame should have ops");
+      // All drawing ops should have gc.ext since ext was set before plot()
+      const ops = frame.plot.ops as Array<Record<string, unknown>>;
+      const opsWithExt = ops.filter(
+        (op) => op.gc && (op.gc as Record<string, unknown>).ext,
+      );
 
-        // All drawing ops should have gc.ext since ext was set before plot()
-        const ops = frame.plot.ops as Array<Record<string, unknown>>;
-        const opsWithExt = ops.filter(
-          (op) => op.gc && (op.gc as Record<string, unknown>).ext,
-        );
+      assert(
+        opsWithExt.length > 0,
+        `Should have ops with gc.ext, got ${opsWithExt.length}`,
+      );
 
-        assert(
-          opsWithExt.length > 0,
-          `Should have ops with gc.ext, got ${opsWithExt.length}`,
-        );
-
-        // Verify the ext content
-        const ext = (opsWithExt[0].gc as Record<string, unknown>).ext as Record<
-          string,
-          unknown
-        >;
-        assertEquals(ext.blendMode, "multiply", "blendMode should be 'multiply'");
-        assertEquals(ext.opacity, 0.5, "opacity should be 0.5");
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
-      }
+      // Verify the ext content
+      const ext = (opsWithExt[0].gc as Record<string, unknown>).ext as Record<
+        string,
+        unknown
+      >;
+      assertEquals(ext.blendMode, "multiply", "blendMode should be 'multiply'");
+      assertEquals(ext.opacity, 0.5, "opacity should be 0.5");
     } finally {
       browser.close();
       await delay(100);
+      await arf.shutdown();
       await server.shutdown();
       server.cleanup();
     }
@@ -76,10 +75,11 @@ Deno.test({
 
 Deno.test({
   name: "E2E: with_jgd_ext() scopes ext and restores on exit",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -87,47 +87,51 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // R code: use with_jgd_ext to scope ext around first plot,
       // then draw second plot without ext
-      const rCode = [
-        'jgd(width=8, height=6, dpi=96)',
-        'with_jgd_ext(\'{"shadow":{"blur":10,"color":"black"}}\', plot(1:3))',
-        'plot(4:6)',
-        'for (i in 1:100) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-      ].join("; ");
+      await arf.eval(
+        "jgd(width=8, height=6, dpi=96); " +
+          'with_jgd_ext(\'{"shadow":{"blur":10,"color":"black"}}\', plot(1:3))',
+      );
 
-      const r = startR(rCode, server.socketPath);
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame1.plot.ops.length > 0, "First frame should have ops");
 
-      try {
-        const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame1.plot.ops.length > 0, "First frame should have ops");
+      // First frame (plot(1:3) inside with_jgd_ext) should have ext
+      const ops1 = frame1.plot.ops as Array<Record<string, unknown>>;
+      const opsWithExt = ops1.filter(
+        (op) => op.gc && (op.gc as Record<string, unknown>).ext,
+      );
+      assert(opsWithExt.length > 0, "First plot should have ops with gc.ext");
+      const shadow =
+        ((opsWithExt[0].gc as Record<string, unknown>).ext as Record<
+          string,
+          unknown
+        >).shadow as Record<string, unknown>;
+      assertEquals(shadow.blur, 10, "shadow.blur should be 10");
 
-        // First frame (plot(1:3) inside with_jgd_ext) should have ext
-        const ops1 = frame1.plot.ops as Array<Record<string, unknown>>;
-        const opsWithExt = ops1.filter(
-          (op) => op.gc && (op.gc as Record<string, unknown>).ext,
-        );
-        assert(opsWithExt.length > 0, "First plot should have ops with gc.ext");
-        const shadow = ((opsWithExt[0].gc as Record<string, unknown>).ext as Record<string, unknown>).shadow as Record<string, unknown>;
-        assertEquals(shadow.blur, 10, "shadow.blur should be 10");
+      await arf.eval("plot(4:6)");
 
-        // Second frame (plot(4:6) after with_jgd_ext scope) should NOT have ext
-        const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame2.plot.ops.length > 0, "Second frame should have ops");
-        const ops2 = frame2.plot.ops as Array<Record<string, unknown>>;
-        const opsWithExt2 = ops2.filter(
-          (op) => op.gc && (op.gc as Record<string, unknown>).ext,
-        );
-        assertEquals(opsWithExt2.length, 0, "Second plot should NOT have gc.ext after with_jgd_ext scope");
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
-      }
+      // Second frame (plot(4:6) after with_jgd_ext scope) should NOT have ext
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame2.plot.ops.length > 0, "Second frame should have ops");
+      const ops2 = frame2.plot.ops as Array<Record<string, unknown>>;
+      const opsWithExt2 = ops2.filter(
+        (op) => op.gc && (op.gc as Record<string, unknown>).ext,
+      );
+      assertEquals(
+        opsWithExt2.length,
+        0,
+        "Second plot should NOT have gc.ext after with_jgd_ext scope",
+      );
     } finally {
       browser.close();
       await delay(100);
+      await arf.shutdown();
       await server.shutdown();
       server.cleanup();
     }
@@ -136,10 +140,11 @@ Deno.test({
 
 Deno.test({
   name: "E2E: gc.ext survives resize (display list replay)",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -147,66 +152,70 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // R code: use with_jgd_ext (sets then clears ext), then poll for resizes.
       // The bug: after with_jgd_ext returns, ext_json is NULL.  When R replays
       // the display list on resize, jgd_ext() is not re-called (it's not in the
       // display list), so all ops in the replayed frame lose gc.ext.
-      const rCode = [
-        'jgd(width=8, height=6, dpi=96)',
-        'with_jgd_ext(\'{"blendMode":"multiply","opacity":0.5}\', plot(1:3))',
-        'for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-      ].join("; ");
+      await arf.eval(
+        "jgd(width=8, height=6, dpi=96); " +
+          'with_jgd_ext(\'{"blendMode":"multiply","opacity":0.5}\', plot(1:3))',
+      );
 
-      const r = startR(rCode, server.socketPath);
+      // Wait for initial frame
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame1.plot.ops.length > 0, "Initial frame should have ops");
 
-      try {
-        // Wait for initial frame
-        const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame1.plot.ops.length > 0, "Initial frame should have ops");
+      const ops1 = frame1.plot.ops as Array<Record<string, unknown>>;
+      const opsWithExt1 = ops1.filter(
+        (op) => op.gc && (op.gc as Record<string, unknown>).ext,
+      );
+      assert(
+        opsWithExt1.length > 0,
+        "Initial frame should have ops with gc.ext",
+      );
 
-        const ops1 = frame1.plot.ops as Array<Record<string, unknown>>;
-        const opsWithExt1 = ops1.filter(
-          (op) => op.gc && (op.gc as Record<string, unknown>).ext,
-        );
-        assert(opsWithExt1.length > 0, "Initial frame should have ops with gc.ext");
+      // Send a resize — this triggers display list replay in R
+      browser.sendResize(640, 480);
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        // Send a resize — this triggers display list replay in R
-        browser.sendResize(640, 480);
+      // Wait for the resize replay frame
+      const resizeFrame = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame",
+        10000,
+      );
+      assert(resizeFrame.plot.ops.length > 0, "Resize frame should have ops");
 
-        // Wait for the resize replay frame
-        const resizeFrame = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame",
-          10000,
-        );
-        assert(resizeFrame.plot.ops.length > 0, "Resize frame should have ops");
+      // CRITICAL: gc.ext must survive the display list replay.
+      // Without recordGraphics, jgd_ext() is not replayed and ext_json
+      // is NULL during replay, causing gc.ext to be missing.
+      const ops2 = resizeFrame.plot.ops as Array<Record<string, unknown>>;
+      const opsWithExt2 = ops2.filter(
+        (op) => op.gc && (op.gc as Record<string, unknown>).ext,
+      );
+      assert(
+        opsWithExt2.length > 0,
+        `Resize frame should preserve gc.ext (got ${opsWithExt2.length} ops with ext)`,
+      );
 
-        // CRITICAL: gc.ext must survive the display list replay.
-        // Without recordGraphics, jgd_ext() is not replayed and ext_json
-        // is NULL during replay, causing gc.ext to be missing.
-        const ops2 = resizeFrame.plot.ops as Array<Record<string, unknown>>;
-        const opsWithExt2 = ops2.filter(
-          (op) => op.gc && (op.gc as Record<string, unknown>).ext,
-        );
-        assert(
-          opsWithExt2.length > 0,
-          `Resize frame should preserve gc.ext (got ${opsWithExt2.length} ops with ext)`,
-        );
-
-        const ext = (opsWithExt2[0].gc as Record<string, unknown>).ext as Record<
-          string,
-          unknown
-        >;
-        assertEquals(ext.blendMode, "multiply", "blendMode should survive resize");
-        assertEquals(ext.opacity, 0.5, "opacity should survive resize");
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
-      }
+      const ext = (opsWithExt2[0].gc as Record<string, unknown>).ext as Record<
+        string,
+        unknown
+      >;
+      assertEquals(
+        ext.blendMode,
+        "multiply",
+        "blendMode should survive resize",
+      );
+      assertEquals(ext.opacity, 0.5, "opacity should survive resize");
     } finally {
       browser.close();
       await delay(100);
+      await arf.shutdown();
       await server.shutdown();
       server.cleanup();
     }
@@ -215,10 +224,11 @@ Deno.test({
 
 Deno.test({
   name: "E2E: gc.ext survives plotIndex resize (historical plot replay)",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -226,91 +236,108 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // R code: draw two plots with different ext, then poll for resizes.
       // Plot 1 gets shadow, plot 2 gets opacity.  After drawing, we resize
       // plot 1 via plotIndex, then resize plot 2 — both must keep their ext.
-      const rCode = [
-        'jgd(width=8, height=6, dpi=96)',
-        'jgd_ext(\'{"shadow":{"blur":10,"color":"gray"}}\')',
-        'plot(1:3)',
-        'jgd_ext(NULL)',
-        'with_jgd_ext(\'{"opacity":0.5}\', plot(4:6))',
-        'for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-      ].join("; ");
+      await arf.eval(
+        "jgd(width=8, height=6, dpi=96); " +
+          'jgd_ext(\'{"shadow":{"blur":10,"color":"gray"}}\'); ' +
+          "plot(1:3)",
+      );
 
-      const r = startR(rCode, server.socketPath);
+      // Receive frame for plot 1 (shadow)
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame1.plot.ops.length > 0, "Plot 1 should have ops");
+      const ops1 = frame1.plot.ops as Array<Record<string, unknown>>;
+      const opsWithShadow = ops1.filter(
+        (op) => op.gc && (op.gc as Record<string, unknown>).ext,
+      );
+      assert(opsWithShadow.length > 0, "Plot 1 should have shadow ext");
 
-      try {
-        // Receive frame for plot 1 (shadow)
-        const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame1.plot.ops.length > 0, "Plot 1 should have ops");
-        const ops1 = frame1.plot.ops as Array<Record<string, unknown>>;
-        const opsWithShadow = ops1.filter(
-          (op) => op.gc && (op.gc as Record<string, unknown>).ext,
-        );
-        assert(opsWithShadow.length > 0, "Plot 1 should have shadow ext");
+      await arf.eval(
+        "jgd_ext(NULL); " +
+          "with_jgd_ext('{\"opacity\":0.5}', plot(4:6))",
+      );
 
-        // Receive frame for plot 2 (opacity)
-        const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame2.plot.ops.length > 0, "Plot 2 should have ops");
-        const ops2 = frame2.plot.ops as Array<Record<string, unknown>>;
-        const opsWithOpacity = ops2.filter(
-          (op) => op.gc && (op.gc as Record<string, unknown>).ext,
-        );
-        assert(opsWithOpacity.length > 0, "Plot 2 should have opacity ext");
+      // Receive frame for plot 2 (opacity)
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame2.plot.ops.length > 0, "Plot 2 should have ops");
+      const ops2 = frame2.plot.ops as Array<Record<string, unknown>>;
+      const opsWithOpacity = ops2.filter(
+        (op) => op.gc && (op.gc as Record<string, unknown>).ext,
+      );
+      assert(opsWithOpacity.length > 0, "Plot 2 should have opacity ext");
 
-        // Resize plot 1 via plotIndex (historical replay)
-        const sessionId = frame1.plot.sessionId!;
-        browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
+      // Resize plot 1 via plotIndex (historical replay)
+      const sessionId = frame1.plot.sessionId!;
+      browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        const replay1 = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
-        assert(replay1.plot.ops.length > 0, "Plot 1 replay should have ops");
-        assertEquals(replay1.plotIndex, 0, "Should be plotIndex 0");
-        const replay1Ops = replay1.plot.ops as Array<Record<string, unknown>>;
-        const replay1Ext = replay1Ops.filter(
-          (op) => op.gc && (op.gc as Record<string, unknown>).ext,
-        );
-        assert(
-          replay1Ext.length > 0,
-          "Plot 1 replay should preserve shadow ext",
-        );
-        const shadow = ((replay1Ext[0].gc as Record<string, unknown>).ext as Record<string, unknown>).shadow as Record<string, unknown>;
-        assertEquals(shadow.blur, 10, "shadow.blur should be 10 after plotIndex resize");
+      const replay1 = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
+      );
+      assert(replay1.plot.ops.length > 0, "Plot 1 replay should have ops");
+      assertEquals(replay1.plotIndex, 0, "Should be plotIndex 0");
+      const replay1Ops = replay1.plot.ops as Array<Record<string, unknown>>;
+      const replay1Ext = replay1Ops.filter(
+        (op) => op.gc && (op.gc as Record<string, unknown>).ext,
+      );
+      assert(
+        replay1Ext.length > 0,
+        "Plot 1 replay should preserve shadow ext",
+      );
+      const shadow =
+        ((replay1Ext[0].gc as Record<string, unknown>).ext as Record<
+          string,
+          unknown
+        >).shadow as Record<string, unknown>;
+      assertEquals(
+        shadow.blur,
+        10,
+        "shadow.blur should be 10 after plotIndex resize",
+      );
 
-        // Now resize the current plot (plot 2) via plotIndex=1.
-        // With 2 plots, plotIndex=1 is the latest plot — R has no snapshot
-        // for it, so it falls through to a normal display list replay.
-        // Its opacity ext must NOT be lost because of the earlier
-        // plotIndex=0 replay.
-        browser.sendResizeWithPlotIndex(700, 500, 1, sessionId);
+      // Now resize the current plot (plot 2) via plotIndex=1.
+      // With 2 plots, plotIndex=1 is the latest plot — R has no snapshot
+      // for it, so it falls through to a normal display list replay.
+      // Its opacity ext must NOT be lost because of the earlier
+      // plotIndex=0 replay.
+      browser.sendResizeWithPlotIndex(700, 500, 1, sessionId);
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        const replay2 = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
-        assert(replay2.plot.ops.length > 0, "Plot 2 replay should have ops");
-        const replay2Ops = replay2.plot.ops as Array<Record<string, unknown>>;
-        const replay2Ext = replay2Ops.filter(
-          (op) => op.gc && (op.gc as Record<string, unknown>).ext,
-        );
-        assert(
-          replay2Ext.length > 0,
-          `Plot 2 replay should preserve opacity ext (got ${replay2Ext.length} ops with ext)`,
-        );
-        const ext2 = (replay2Ext[0].gc as Record<string, unknown>).ext as Record<string, unknown>;
-        assertEquals(ext2.opacity, 0.5, "opacity should survive after plotIndex replay");
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
-      }
+      const replay2 = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
+      );
+      assert(replay2.plot.ops.length > 0, "Plot 2 replay should have ops");
+      const replay2Ops = replay2.plot.ops as Array<Record<string, unknown>>;
+      const replay2Ext = replay2Ops.filter(
+        (op) => op.gc && (op.gc as Record<string, unknown>).ext,
+      );
+      assert(
+        replay2Ext.length > 0,
+        `Plot 2 replay should preserve opacity ext (got ${replay2Ext.length} ops with ext)`,
+      );
+      const ext2 = (replay2Ext[0].gc as Record<string, unknown>).ext as Record<
+        string,
+        unknown
+      >;
+      assertEquals(
+        ext2.opacity,
+        0.5,
+        "opacity should survive after plotIndex replay",
+      );
     } finally {
       browser.close();
       await delay(100);
+      await arf.shutdown();
       await server.shutdown();
       server.cleanup();
     }

--- a/tests/gc_ext_e2e_test.ts
+++ b/tests/gc_ext_e2e_test.ts
@@ -10,6 +10,7 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { testLog } from "./helpers/test_log.ts";
@@ -184,8 +185,8 @@ Deno.test({
 
       // Send a resize — this triggers display list replay in R
       browser.sendResize(640, 480);
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       // Wait for the resize replay frame
       const resizeFrame = await browser.waitForMessage<FrameMessage>(
@@ -280,8 +281,8 @@ Deno.test({
       // Resize plot 1 via plotIndex (historical replay)
       const sessionId = frame1.plot.sessionId!;
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const replay1 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
@@ -314,8 +315,8 @@ Deno.test({
       // Its opacity ext must NOT be lost because of the earlier
       // plotIndex=0 replay.
       browser.sendResizeWithPlotIndex(700, 500, 1, sessionId);
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const replay2 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,

--- a/tests/gc_ext_e2e_test.ts
+++ b/tests/gc_ext_e2e_test.ts
@@ -10,11 +10,11 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name: "E2E: jgd_ext() embeds gc.ext in frame ops",

--- a/tests/gc_ext_e2e_test.ts
+++ b/tests/gc_ext_e2e_test.ts
@@ -144,10 +144,19 @@ Deno.test({
       // Send a resize — this triggers display list replay in R
       await sendResizeAndPoll(ctx, 640, 480);
 
-      // Wait for the resize replay frame
+      // Wait for the resize replay frame.  Filter on resize:true so a
+      // stale/untagged frame from initial drawing cannot satisfy this
+      // assertion against the wrong message — the ext-preservation check
+      // below must run on the actual display-list-replay frame.
       const resizeFrame = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame",
+        (msg) =>
+          msg.type === "frame" && (msg as FrameMessage).resize === true,
         6000,
+      );
+      assertEquals(
+        resizeFrame.resize,
+        true,
+        "Resize replay frame must be tagged resize:true",
       );
       assert(resizeFrame.plot.ops.length > 0, "Resize frame should have ops");
 

--- a/tests/gc_ext_e2e_test.ts
+++ b/tests/gc_ext_e2e_test.ts
@@ -6,13 +6,13 @@
  */
 
 import { assert, assertEquals } from "@std/assert";
-import { delay } from "@std/async";
-import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
-import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { pollResize } from "./helpers/arf_poll.ts";
-import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
-import { toRSocketAddress } from "./helpers/r_process.ts";
+import {
+  sendPlotIndexResizeAndPoll,
+  sendResizeAndPoll,
+  startArfBrowserTest,
+} from "./helpers/arf_e2e.ts";
+import { checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
@@ -23,25 +23,13 @@ Deno.test({
   ignore: skip,
   async fn() {
     testLog("test start");
-    const server = new TestServer({ tcp: true });
-    const browser = new AutoMetricsBrowserClient();
-    const arf = new ArfSession();
+    const ctx = await startArfBrowserTest();
+    const { arf, browser } = ctx;
 
     try {
-      await server.start();
-      await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
-      await arf.start();
-      const socketAddr = toRSocketAddress(server.socketPath);
-
-      // Setup: load jgd with socket
-      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // R code: set ext, draw a plot, verify ext is embedded in ops
       await arf.eval(
-        "jgd(width=8, height=6, dpi=96); " +
-          'jgd_ext(\'{"blendMode":"multiply","opacity":0.5}\'); ' +
+        'jgd_ext(\'{"blendMode":"multiply","opacity":0.5}\'); ' +
           "plot(1:3)",
       );
 
@@ -67,11 +55,7 @@ Deno.test({
       assertEquals(ext.blendMode, "multiply", "blendMode should be 'multiply'");
       assertEquals(ext.opacity, 0.5, "opacity should be 0.5");
     } finally {
-      browser.close();
-      await delay(100);
-      await arf.shutdown();
-      await server.shutdown();
-      server.cleanup();
+      await ctx.close();
     }
   },
 });
@@ -81,25 +65,14 @@ Deno.test({
   ignore: skip,
   async fn() {
     testLog("test start");
-    const server = new TestServer({ tcp: true });
-    const browser = new AutoMetricsBrowserClient();
-    const arf = new ArfSession();
+    const ctx = await startArfBrowserTest();
+    const { arf, browser } = ctx;
 
     try {
-      await server.start();
-      await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
-      await arf.start();
-      const socketAddr = toRSocketAddress(server.socketPath);
-
-      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // R code: use with_jgd_ext to scope ext around first plot,
       // then draw second plot without ext
       await arf.eval(
-        "jgd(width=8, height=6, dpi=96); " +
-          'with_jgd_ext(\'{"shadow":{"blur":10,"color":"black"}}\', plot(1:3))',
+        'with_jgd_ext(\'{"shadow":{"blur":10,"color":"black"}}\', plot(1:3))',
       );
 
       const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
@@ -133,11 +106,7 @@ Deno.test({
         "Second plot should NOT have gc.ext after with_jgd_ext scope",
       );
     } finally {
-      browser.close();
-      await delay(100);
-      await arf.shutdown();
-      await server.shutdown();
-      server.cleanup();
+      await ctx.close();
     }
   },
 });
@@ -147,27 +116,16 @@ Deno.test({
   ignore: skip,
   async fn() {
     testLog("test start");
-    const server = new TestServer({ tcp: true });
-    const browser = new AutoMetricsBrowserClient();
-    const arf = new ArfSession();
+    const ctx = await startArfBrowserTest();
+    const { arf, browser } = ctx;
 
     try {
-      await server.start();
-      await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
-      await arf.start();
-      const socketAddr = toRSocketAddress(server.socketPath);
-
-      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // R code: use with_jgd_ext (sets then clears ext), then poll for resizes.
       // The bug: after with_jgd_ext returns, ext_json is NULL.  When R replays
       // the display list on resize, jgd_ext() is not re-called (it's not in the
       // display list), so all ops in the replayed frame lose gc.ext.
       await arf.eval(
-        "jgd(width=8, height=6, dpi=96); " +
-          'with_jgd_ext(\'{"blendMode":"multiply","opacity":0.5}\', plot(1:3))',
+        'with_jgd_ext(\'{"blendMode":"multiply","opacity":0.5}\', plot(1:3))',
       );
 
       // Wait for initial frame
@@ -184,9 +142,7 @@ Deno.test({
       );
 
       // Send a resize — this triggers display list replay in R
-      browser.sendResize(640, 480);
-      await browser.sendPing(3000);
-      await pollResize(arf, 40);
+      await sendResizeAndPoll(ctx, 640, 480);
 
       // Wait for the resize replay frame
       const resizeFrame = await browser.waitForMessage<FrameMessage>(
@@ -218,11 +174,7 @@ Deno.test({
       );
       assertEquals(ext.opacity, 0.5, "opacity should survive resize");
     } finally {
-      browser.close();
-      await delay(100);
-      await arf.shutdown();
-      await server.shutdown();
-      server.cleanup();
+      await ctx.close();
     }
   },
 });
@@ -232,26 +184,15 @@ Deno.test({
   ignore: skip,
   async fn() {
     testLog("test start");
-    const server = new TestServer({ tcp: true });
-    const browser = new AutoMetricsBrowserClient();
-    const arf = new ArfSession();
+    const ctx = await startArfBrowserTest();
+    const { arf, browser } = ctx;
 
     try {
-      await server.start();
-      await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
-      await arf.start();
-      const socketAddr = toRSocketAddress(server.socketPath);
-
-      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // R code: draw two plots with different ext, then poll for resizes.
       // Plot 1 gets shadow, plot 2 gets opacity.  After drawing, we resize
       // plot 1 via plotIndex, then resize plot 2 — both must keep their ext.
       await arf.eval(
-        "jgd(width=8, height=6, dpi=96); " +
-          'jgd_ext(\'{"shadow":{"blur":10,"color":"gray"}}\'); ' +
+        'jgd_ext(\'{"shadow":{"blur":10,"color":"gray"}}\'); ' +
           "plot(1:3)",
       );
 
@@ -280,9 +221,7 @@ Deno.test({
 
       // Resize plot 1 via plotIndex (historical replay)
       const sessionId = frame1.plot.sessionId!;
-      browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
-      await browser.sendPing(3000);
-      await pollResize(arf, 40);
+      await sendPlotIndexResizeAndPoll(ctx, 640, 480, 0, sessionId);
 
       const replay1 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
@@ -314,9 +253,7 @@ Deno.test({
       // for it, so it falls through to a normal display list replay.
       // Its opacity ext must NOT be lost because of the earlier
       // plotIndex=0 replay.
-      browser.sendResizeWithPlotIndex(700, 500, 1, sessionId);
-      await browser.sendPing(3000);
-      await pollResize(arf, 40);
+      await sendPlotIndexResizeAndPoll(ctx, 700, 500, 1, sessionId);
 
       const replay2 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
@@ -341,11 +278,7 @@ Deno.test({
         "opacity should survive after plotIndex replay",
       );
     } finally {
-      browser.close();
-      await delay(100);
-      await arf.shutdown();
-      await server.shutdown();
-      server.cleanup();
+      await ctx.close();
     }
   },
 });

--- a/tests/gc_ext_e2e_test.ts
+++ b/tests/gc_ext_e2e_test.ts
@@ -12,6 +12,7 @@ import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
@@ -20,6 +21,7 @@ Deno.test({
   name: "E2E: jgd_ext() embeds gc.ext in frame ops",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -77,6 +79,7 @@ Deno.test({
   name: "E2E: with_jgd_ext() scopes ext and restores on exit",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -142,6 +145,7 @@ Deno.test({
   name: "E2E: gc.ext survives resize (display list replay)",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -226,6 +230,7 @@ Deno.test({
   name: "E2E: gc.ext survives plotIndex resize (historical plot replay)",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/gc_ext_e2e_test.ts
+++ b/tests/gc_ext_e2e_test.ts
@@ -28,7 +28,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -42,7 +42,7 @@ Deno.test({
           "plot(1:3)",
       );
 
-      const frame = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame.plot.ops.length > 0, "Frame should have ops");
 
       // All drawing ops should have gc.ext since ext was set before plot()
@@ -85,7 +85,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -98,7 +98,7 @@ Deno.test({
           'with_jgd_ext(\'{"shadow":{"blur":10,"color":"black"}}\', plot(1:3))',
       );
 
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame1.plot.ops.length > 0, "First frame should have ops");
 
       // First frame (plot(1:3) inside with_jgd_ext) should have ext
@@ -117,7 +117,7 @@ Deno.test({
       await arf.eval("plot(4:6)");
 
       // Second frame (plot(4:6) after with_jgd_ext scope) should NOT have ext
-      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame2.plot.ops.length > 0, "Second frame should have ops");
       const ops2 = frame2.plot.ops as Array<Record<string, unknown>>;
       const opsWithExt2 = ops2.filter(
@@ -150,7 +150,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -166,7 +166,7 @@ Deno.test({
       );
 
       // Wait for initial frame
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame1.plot.ops.length > 0, "Initial frame should have ops");
 
       const ops1 = frame1.plot.ops as Array<Record<string, unknown>>;
@@ -186,7 +186,7 @@ Deno.test({
       // Wait for the resize replay frame
       const resizeFrame = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame",
-        10000,
+        6000,
       );
       assert(resizeFrame.plot.ops.length > 0, "Resize frame should have ops");
 
@@ -234,7 +234,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -250,7 +250,7 @@ Deno.test({
       );
 
       // Receive frame for plot 1 (shadow)
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame1.plot.ops.length > 0, "Plot 1 should have ops");
       const ops1 = frame1.plot.ops as Array<Record<string, unknown>>;
       const opsWithShadow = ops1.filter(
@@ -264,7 +264,7 @@ Deno.test({
       );
 
       // Receive frame for plot 2 (opacity)
-      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame2.plot.ops.length > 0, "Plot 2 should have ops");
       const ops2 = frame2.plot.ops as Array<Record<string, unknown>>;
       const opsWithOpacity = ops2.filter(
@@ -280,7 +280,7 @@ Deno.test({
 
       const replay1 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
       assert(replay1.plot.ops.length > 0, "Plot 1 replay should have ops");
       assertEquals(replay1.plotIndex, 0, "Should be plotIndex 0");
@@ -314,7 +314,7 @@ Deno.test({
 
       const replay2 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
       assert(replay2.plot.ops.length > 0, "Plot 2 replay should have ops");
       const replay2Ops = replay2.plot.ops as Array<Record<string, unknown>>;

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -24,9 +24,10 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
 
 /** Check if ggplot2 is installed in R. */
 async function checkGgplot2Available(): Promise<boolean> {
@@ -44,7 +45,62 @@ async function checkGgplot2Available(): Promise<boolean> {
   }
 }
 
-const ggplot2Available = rAvailable && await checkGgplot2Available();
+const ggplot2Available = arfAvailable && await checkGgplot2Available();
+const FRAME_WAIT_MS = 1000;
+const NEWPAGE_DEADLINE_MS = 2000;
+
+async function evalOk(
+  arf: ArfSession,
+  code: string,
+  timeoutMs?: number,
+): Promise<void> {
+  const result = await arf.eval(code, timeoutMs);
+  assertEquals(result.error, null, `R eval failed: ${result.error}`);
+}
+
+async function pollR(arf: ArfSession, iterations = 120): Promise<void> {
+  await evalOk(
+    arf,
+    `for (i in 1:${iterations}) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }`,
+    60_000,
+  );
+}
+
+async function collectFramesUntilQuiet(
+  browser: AutoMetricsBrowserClient,
+  quietMs = 1000,
+): Promise<FrameMessage[]> {
+  const frames: FrameMessage[] = [];
+  while (true) {
+    try {
+      frames.push(await browser.waitForType<FrameMessage>("frame", quietMs));
+    } catch {
+      break;
+    }
+  }
+  return frames;
+}
+
+async function collectFramesUntilNewPagesOrDeadline(
+  browser: AutoMetricsBrowserClient,
+  requiredNewPages: number,
+  perWaitMs = FRAME_WAIT_MS,
+  deadlineMs = NEWPAGE_DEADLINE_MS,
+): Promise<FrameMessage[]> {
+  const frames: FrameMessage[] = [];
+  let newPageCount = 0;
+  const deadline = Date.now() + deadlineMs;
+  while (newPageCount < requiredNewPages && Date.now() < deadline) {
+    try {
+      const frame = await browser.waitForType<FrameMessage>("frame", perWaitMs);
+      frames.push(frame);
+      if (frame.newPage) newPageCount++;
+    } catch {
+      // Keep polling until deadline. ggplot2 frame gaps can be bursty.
+    }
+  }
+  return frames;
+}
 
 // ---------------------------------------------------------------------------
 // Bug 1: Two ggplot2 plots must produce exactly 2 addPlot-triggering frames
@@ -56,6 +112,7 @@ Deno.test({
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -63,101 +120,76 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      await evalOk(arf, `options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // Two ggplot2 faceted plots.  facet_wrap produces many incremental
       // frames and leaves some ops unflushed when the second plot starts.
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); library(ggplot2); ' +
-          'ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw(); ' +
-          'ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw(); ' +
-          'for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await evalOk(arf, "jgd(width=8, height=6, dpi=96)");
+      await evalOk(
+        arf,
+        "library(ggplot2); " +
+          "print(ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw()); " +
+          "print(ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw())",
+        60_000,
+      );
+      await pollR(arf);
+
+      // Collect frames until drawing settles, then classify.
+      const allFrames = await collectFramesUntilNewPagesOrDeadline(browser, 2);
+
+      // Categorize frames.
+      // Browser dispatch: resize → replaceLatest, incremental → appendOps,
+      // else (including newPage) → addPlot.  So addPlot-triggering =
+      // newPage frames + untagged complete frames.
+      const newPageFrames = allFrames.filter((f) => f.newPage === true);
+      const incrementalFrames = allFrames.filter(
+        (f) => f.incremental === true,
+      );
+      const untaggedCompleteFrames = allFrames.filter(
+        (f) => !f.newPage && !f.resize && !f.incremental,
       );
 
-      try {
-        // Collect frames until we see 2 newPage frames (= 2 plots started)
-        const allFrames: FrameMessage[] = [];
-        let newPageCount = 0;
+      console.error(
+        `\nggplot2 frame summary: total=${allFrames.length}, ` +
+          `newPage=${newPageFrames.length}, ` +
+          `incremental=${incrementalFrames.length}, ` +
+          `untaggedComplete=${untaggedCompleteFrames.length}`,
+      );
 
-        while (newPageCount < 2) {
-          const frame = await browser.waitForType<FrameMessage>(
-            "frame",
-            15000,
+      // Log non-incremental frames for debugging
+      for (let i = 0; i < allFrames.length; i++) {
+        const f = allFrames[i];
+        if (!f.incremental) {
+          console.error(
+            `  frame[${i}]: newPage=${f.newPage}, resize=${f.resize}, ` +
+              `incremental=${f.incremental}, ops=${f.plot.ops.length}`,
           );
-          allFrames.push(frame);
-          if (frame.newPage) newPageCount++;
         }
-
-        // Drain remaining incremental frames for the second plot
-        await delay(2000);
-        let draining = true;
-        while (draining) {
-          try {
-            const frame = await browser.waitForType<FrameMessage>(
-              "frame",
-              1000,
-            );
-            allFrames.push(frame);
-          } catch {
-            draining = false;
-          }
-        }
-
-        // Categorize frames.
-        // Browser dispatch: resize → replaceLatest, incremental → appendOps,
-        // else (including newPage) → addPlot.  So addPlot-triggering =
-        // newPage frames + untagged complete frames.
-        const newPageFrames = allFrames.filter((f) => f.newPage === true);
-        const incrementalFrames = allFrames.filter(
-          (f) => f.incremental === true,
-        );
-        const untaggedCompleteFrames = allFrames.filter(
-          (f) => !f.newPage && !f.resize && !f.incremental,
-        );
-
-        console.error(
-          `\nggplot2 frame summary: total=${allFrames.length}, ` +
-            `newPage=${newPageFrames.length}, ` +
-            `incremental=${incrementalFrames.length}, ` +
-            `untaggedComplete=${untaggedCompleteFrames.length}`,
-        );
-
-        // Log non-incremental frames for debugging
-        for (let i = 0; i < allFrames.length; i++) {
-          const f = allFrames[i];
-          if (!f.incremental) {
-            console.error(
-              `  frame[${i}]: newPage=${f.newPage}, resize=${f.resize}, ` +
-                `incremental=${f.incremental}, ops=${f.plot.ops.length}`,
-            );
-          }
-        }
-
-        assertEquals(
-          newPageFrames.length,
-          2,
-          `Expected 2 newPage frames for 2 ggplot2 plots`,
-        );
-
-        // Key assertion: no untagged complete frames between the two plots.
-        // These would cause addPlot → spurious third history entry.
-        // (addPlot count = newPage + untaggedComplete, so with 2 newPages
-        // we need 0 untaggedComplete to get exactly 2 history entries.)
-        assertEquals(
-          untaggedCompleteFrames.length,
-          0,
-          `Untagged complete frames cause spurious history entries: ` +
-            `got ${untaggedCompleteFrames.length}. ` +
-            `cb_newPage should flush remaining ops as incremental.`,
-        );
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
       }
+
+      assertEquals(
+        newPageFrames.length,
+        2,
+        `Expected 2 newPage frames for 2 ggplot2 plots`,
+      );
+
+      // Key assertion: no untagged complete frames between the two plots.
+      // These would cause addPlot → spurious third history entry.
+      // (addPlot count = newPage + untaggedComplete, so with 2 newPages
+      // we need 0 untaggedComplete to get exactly 2 history entries.)
+      assertEquals(
+        untaggedCompleteFrames.length,
+        0,
+        `Untagged complete frames cause spurious history entries: ` +
+          `got ${untaggedCompleteFrames.length}. ` +
+          `cb_newPage should flush remaining ops as incremental.`,
+      );
     } finally {
       browser.close();
       await delay(100);
+      await arf.shutdown();
       await server.shutdown();
       server.cleanup();
     }
@@ -169,11 +201,13 @@ Deno.test({
 // ---------------------------------------------------------------------------
 
 Deno.test({
-  name: "ggplot2: plotIndex resize must replay full plot (not just initial ops)",
+  name:
+    "ggplot2: plotIndex resize must replay full plot (not just initial ops)",
   ignore: !ggplot2Available,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -181,105 +215,92 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      await evalOk(arf, `options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // Two ggplot2 plots, then poll_resize to handle the plotIndex resize.
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); library(ggplot2); ' +
-          'ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw(); ' +
-          'ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw(); ' +
-          'for (i in 1:400) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await evalOk(arf, "jgd(width=8, height=6, dpi=96)");
+      await evalOk(
+        arf,
+        "library(ggplot2); " +
+          "print(ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw()); " +
+          "print(ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw())",
+        60_000,
+      );
+      await pollR(arf);
+
+      // Wait for both plots: collect until drawing settles
+      let sessionId = "";
+      let firstPlotOpsTotal = 0;
+      const frames = await collectFramesUntilNewPagesOrDeadline(browser, 2);
+      let newPageCount = 0;
+      for (const frame of frames) {
+        if (frame.newPage) {
+          newPageCount++;
+          if (newPageCount === 1) sessionId = frame.plot.sessionId || "";
+          if (newPageCount === 2) continue;
+        }
+        if (newPageCount === 1) firstPlotOpsTotal += frame.plot.ops.length;
+      }
+      assertEquals(
+        newPageCount,
+        2,
+        `Expected 2 newPage frames, got ${newPageCount}`,
       );
 
-      try {
-        // Wait for both plots: collect until we see 2 newPage frames
-        let newPageCount = 0;
-        let sessionId = "";
-        let firstPlotOpsTotal = 0;
+      assert(sessionId, "Should have received sessionId from R");
+      assert(
+        firstPlotOpsTotal > 50,
+        `First ggplot2 plot should have many ops, got ${firstPlotOpsTotal}`,
+      );
 
-        while (newPageCount < 2) {
-          const frame = await browser.waitForType<FrameMessage>(
-            "frame",
-            15000,
-          );
-          if (frame.newPage) {
-            newPageCount++;
-            if (newPageCount === 1) {
-              sessionId = frame.plot.sessionId || "";
-            }
-          }
-          // Track total ops for the first plot (newPage + incrementals before
-          // the second newPage).
-          if (newPageCount === 1) {
-            firstPlotOpsTotal += frame.plot.ops.length;
-          }
-        }
+      console.error(
+        `\nFirst plot total ops: ${firstPlotOpsTotal}, sessionId: ${sessionId}`,
+      );
 
-        // Drain remaining frames from the second plot
-        await delay(2000);
-        let draining = true;
-        while (draining) {
-          try {
-            await browser.waitForType<FrameMessage>("frame", 1000);
-          } catch {
-            draining = false;
-          }
-        }
+      // Now send a plotIndex resize for plot 0 (the first ggplot)
+      browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
+      await delay(100);
+      await pollR(arf, 40);
 
-        assert(sessionId, "Should have received sessionId from R");
-        assert(
-          firstPlotOpsTotal > 50,
-          `First ggplot2 plot should have many ops, got ${firstPlotOpsTotal}`,
-        );
+      // Wait for the plotIndex replay frame
+      const replayFrame = await browser.waitForMessage<FrameMessage>(
+        (msg) =>
+          msg.type === "frame" &&
+          !("incremental" in msg && (msg as FrameMessage).incremental),
+        10000,
+      );
 
-        console.error(
-          `\nFirst plot total ops: ${firstPlotOpsTotal}, sessionId: ${sessionId}`,
-        );
+      console.error(
+        `\nplotIndex replay: ops=${replayFrame.plot.ops.length}, ` +
+          `resize=${replayFrame.resize}, plotIndex=${replayFrame.plotIndex}`,
+      );
 
-        // Now send a plotIndex resize for plot 0 (the first ggplot)
-        browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
+      assertEquals(
+        replayFrame.resize,
+        true,
+        "plotIndex replay frame must be tagged resize:true",
+      );
 
-        // Wait for the plotIndex replay frame
-        const replayFrame = await browser.waitForMessage<FrameMessage>(
-          (msg) =>
-            msg.type === "frame" &&
-            !("incremental" in msg && (msg as FrameMessage).incremental),
-          10000,
-        );
-
-        console.error(
-          `\nplotIndex replay: ops=${replayFrame.plot.ops.length}, ` +
-            `resize=${replayFrame.resize}, plotIndex=${replayFrame.plotIndex}`,
-        );
-
-        assertEquals(
-          replayFrame.resize,
-          true,
-          "plotIndex replay frame must be tagged resize:true",
-        );
-
-        // Key assertion: the replay must contain a substantial number of ops.
-        // If the snapshot was incomplete (only initial page setup ~7 ops),
-        // the replay would have very few ops → white/empty image.
-        //
-        // A full ggplot2 faceted plot typically has 400+ ops.  We use a
-        // conservative threshold of 50 to avoid flakiness while still
-        // catching the "only 7 initial ops" bug.
-        assert(
-          replayFrame.plot.ops.length > 50,
-          `plotIndex replay should contain the full plot, ` +
-            `got only ${replayFrame.plot.ops.length} ops ` +
-            `(first plot had ${firstPlotOpsTotal} total). ` +
-            `Snapshot was likely incomplete (only initial page setup).`,
-        );
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
-      }
+      // Key assertion: the replay must contain a substantial number of ops.
+      // If the snapshot was incomplete (only initial page setup ~7 ops),
+      // the replay would have very few ops → white/empty image.
+      //
+      // A full ggplot2 faceted plot typically has 400+ ops.  We use a
+      // conservative threshold of 50 to avoid flakiness while still
+      // catching the "only 7 initial ops" bug.
+      assert(
+        replayFrame.plot.ops.length > 50,
+        `plotIndex replay should contain the full plot, ` +
+          `got only ${replayFrame.plot.ops.length} ops ` +
+          `(first plot had ${firstPlotOpsTotal} total). ` +
+          `Snapshot was likely incomplete (only initial page setup).`,
+      );
     } finally {
       browser.close();
       await delay(100);
+      await arf.shutdown();
       await server.shutdown();
       server.cleanup();
     }

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -24,6 +24,7 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { checkGgplot2Available } from "./helpers/r_packages.ts";
@@ -33,23 +34,6 @@ const arfTestAvailable = await checkArfTestAvailable();
 const ggplot2Available = arfTestAvailable && await checkGgplot2Available();
 const FRAME_WAIT_MS = 1000;
 const NEWPAGE_DEADLINE_MS = 2000;
-
-async function evalOk(
-  arf: ArfSession,
-  code: string,
-  timeoutMs?: number,
-): Promise<void> {
-  const result = await arf.eval(code, timeoutMs);
-  assertEquals(result.error, null, `R eval failed: ${result.error}`);
-}
-
-async function pollR(arf: ArfSession, iterations = 120): Promise<void> {
-  await evalOk(
-    arf,
-    `for (i in 1:${iterations}) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }`,
-    60_000,
-  );
-}
 
 async function collectFramesUntilQuiet(
   browser: AutoMetricsBrowserClient,
@@ -109,18 +93,17 @@ Deno.test({
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
 
-      await evalOk(arf, `options(jgd.socket = "${socketAddr}"); library(jgd)`);
+      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // Two ggplot2 faceted plots.  facet_wrap produces many incremental
       // frames and leaves some ops unflushed when the second plot starts.
-      await evalOk(arf, "jgd(width=8, height=6, dpi=96)");
-      await evalOk(
-        arf,
+      await arf.eval("jgd(width=8, height=6, dpi=96)");
+      await arf.eval(
         "library(ggplot2); " +
           "print(ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw()); " +
           "print(ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw())",
         60_000,
       );
-      await pollR(arf);
+      await pollResize(arf);
 
       // Collect until 2 newPage frames, then drain trailing frames so
       // assertions also cover late-arriving complete frames.
@@ -209,17 +192,16 @@ Deno.test({
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
 
-      await evalOk(arf, `options(jgd.socket = "${socketAddr}"); library(jgd)`);
+      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
       // Two ggplot2 plots, then poll_resize to handle the plotIndex resize.
-      await evalOk(arf, "jgd(width=8, height=6, dpi=96)");
-      await evalOk(
-        arf,
+      await arf.eval("jgd(width=8, height=6, dpi=96)");
+      await arf.eval(
         "library(ggplot2); " +
           "print(ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw()); " +
           "print(ggplot(mpg, aes(displ, hwy, col=class)) + geom_point() + facet_wrap(~drv) + theme_bw())",
         60_000,
       );
-      await pollR(arf);
+      await pollResize(arf);
 
       // Wait for both plots: collect until drawing settles
       let sessionId = "";
@@ -256,7 +238,7 @@ Deno.test({
       // Now send a plotIndex resize for plot 0 (the first ggplot)
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
       await delay(100);
-      await pollR(arf, 40);
+      await pollResize(arf, 40);
 
       // Wait for the plotIndex replay frame
       const replayFrame = await browser.waitForMessage<FrameMessage>(

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -26,6 +26,7 @@ import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 
@@ -110,6 +111,7 @@ Deno.test({
   name: "ggplot2: two plots must not create spurious history entry",
   ignore: !ggplot2Available,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -209,6 +211,7 @@ Deno.test({
     "ggplot2: plotIndex resize must replay full plot (not just initial ops)",
   ignore: !ggplot2Available,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -118,7 +118,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -213,7 +213,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -269,7 +269,7 @@ Deno.test({
         (msg) =>
           msg.type === "frame" &&
           !("incremental" in msg && (msg as FrameMessage).incremental),
-        10000,
+        6000,
       );
 
       console.error(

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -136,8 +136,12 @@ Deno.test({
       );
       await pollR(arf);
 
-      // Collect frames until drawing settles, then classify.
+      // Collect until 2 newPage frames, then drain trailing frames so
+      // assertions also cover late-arriving complete frames.
       const allFrames = await collectFramesUntilNewPagesOrDeadline(browser, 2);
+      allFrames.push(
+        ...(await collectFramesUntilQuiet(browser, FRAME_WAIT_MS)),
+      );
 
       // Categorize frames.
       // Browser dispatch: resize → replaceLatest, incremental → appendOps,

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -237,7 +237,9 @@ Deno.test({
 
       // Now send a plotIndex resize for plot 0 (the first ggplot)
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
-      await delay(100);
+      // Ping ordering probe replaces a fixed delay: the FIFO WebSocket
+      // guarantees the server has enqueued the resize before R polls.
+      await browser.sendPing(3000);
       await pollResize(arf, 40);
 
       // Wait for the plotIndex replay frame

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -279,7 +279,8 @@ Deno.test({
         (msg) =>
           msg.type === "frame" &&
           (msg as FrameMessage).resize === true &&
-          (msg as FrameMessage).plotIndex === 0,
+          (msg as FrameMessage).plotIndex === 0 &&
+          (msg as FrameMessage).incremental !== true,
         6000,
       );
 

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -87,9 +87,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
 
@@ -186,9 +183,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
 

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -24,10 +24,10 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const arfAvailable = await checkArfAvailable();
+const arfTestAvailable = await checkArfTestAvailable();
 
 /** Check if ggplot2 is installed in R. */
 async function checkGgplot2Available(): Promise<boolean> {
@@ -45,7 +45,7 @@ async function checkGgplot2Available(): Promise<boolean> {
   }
 }
 
-const ggplot2Available = arfAvailable && await checkGgplot2Available();
+const ggplot2Available = arfTestAvailable && await checkGgplot2Available();
 const FRAME_WAIT_MS = 1000;
 const NEWPAGE_DEADLINE_MS = 2000;
 

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -26,26 +26,10 @@ import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { checkGgplot2Available } from "./helpers/r_packages.ts";
 import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
-
-/** Check if ggplot2 is installed in R. */
-async function checkGgplot2Available(): Promise<boolean> {
-  try {
-    const cmd = new Deno.Command("Rscript", {
-      args: ["-e", 'library(ggplot2); cat("ok")'],
-      stdout: "piped",
-      stderr: "piped",
-    });
-    const output = await cmd.output();
-    const stdout = new TextDecoder().decode(output.stdout);
-    return output.success && stdout.includes("ok");
-  } catch {
-    return false;
-  }
-}
-
 const ggplot2Available = arfTestAvailable && await checkGgplot2Available();
 const FRAME_WAIT_MS = 1000;
 const NEWPAGE_DEADLINE_MS = 2000;

--- a/tests/ggplot2_newpage_test.ts
+++ b/tests/ggplot2_newpage_test.ts
@@ -266,6 +266,9 @@ Deno.test({
         `\nFirst plot total ops: ${firstPlotOpsTotal}, sessionId: ${sessionId}`,
       );
 
+      // Drain any stale complete frames from initial drawing before replay.
+      await collectFramesUntilQuiet(browser, FRAME_WAIT_MS);
+
       // Now send a plotIndex resize for plot 0 (the first ggplot)
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
       await delay(100);
@@ -275,7 +278,8 @@ Deno.test({
       const replayFrame = await browser.waitForMessage<FrameMessage>(
         (msg) =>
           msg.type === "frame" &&
-          !("incremental" in msg && (msg as FrameMessage).incremental),
+          (msg as FrameMessage).resize === true &&
+          (msg as FrameMessage).plotIndex === 0,
         6000,
       );
 

--- a/tests/helpers/arf_e2e.ts
+++ b/tests/helpers/arf_e2e.ts
@@ -25,19 +25,49 @@ export interface ArfPageTestContext {
   close(): Promise<void>;
 }
 
+async function runCleanupSteps(
+  steps: Array<() => Promise<void> | void>,
+): Promise<void> {
+  const errors: unknown[] = [];
+
+  for (const step of steps) {
+    try {
+      await step();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "Multiple cleanup steps failed");
+  }
+}
+
+async function cleanupAfterSetupFailure(
+  cleanup: () => Promise<void>,
+): Promise<void> {
+  try {
+    await cleanup();
+  } catch {
+    // Preserve the original setup error while still attempting cleanup.
+  }
+}
+
 async function closeArfBrowserResources(
   server: TestServer,
   browser: AutoMetricsBrowserClient,
   arf: ArfSession,
 ): Promise<void> {
-  browser.close();
-  await delay(100);
-  try {
-    await server.shutdown();
-  } finally {
-    server.cleanup();
-    await arf.shutdown();
-  }
+  await runCleanupSteps([
+    () => browser.close(),
+    () => delay(100),
+    () => server.shutdown(),
+    () => server.cleanup(),
+    () => arf.shutdown(),
+  ]);
 }
 
 async function closeArfPageResources(
@@ -45,14 +75,13 @@ async function closeArfPageResources(
   e2e: E2EBrowser,
   arf: ArfSession,
 ): Promise<void> {
-  await arf.shutdown();
-  await e2e.close();
-  await delay(100);
-  try {
-    await server.shutdown();
-  } finally {
-    server.cleanup();
-  }
+  await runCleanupSteps([
+    () => arf.shutdown(),
+    () => e2e.close(),
+    () => delay(100),
+    () => server.shutdown(),
+    () => server.cleanup(),
+  ]);
 }
 
 export async function startArfBrowserTest(): Promise<ArfBrowserTestContext> {
@@ -82,7 +111,9 @@ export async function startArfBrowserTest(): Promise<ArfBrowserTestContext> {
       },
     };
   } catch (error) {
-    await closeArfBrowserResources(server, browser, arf);
+    await cleanupAfterSetupFailure(() =>
+      closeArfBrowserResources(server, browser, arf)
+    );
     throw error;
   }
 }
@@ -131,7 +162,9 @@ export async function startArfPageTest(
       },
     };
   } catch (error) {
-    await closeArfPageResources(server, e2e, arf);
+    await cleanupAfterSetupFailure(() =>
+      closeArfPageResources(server, e2e, arf)
+    );
     throw error;
   }
 }

--- a/tests/helpers/arf_e2e.ts
+++ b/tests/helpers/arf_e2e.ts
@@ -6,6 +6,7 @@ import type { FrameMessage } from "../../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./auto_metrics_client.ts";
 import { pollResize } from "./arf_poll.ts";
 import { ArfSession } from "./arf_session.ts";
+import { waitForWsConnected } from "./page_ready.ts";
 import { toRSocketAddress } from "./r_process.ts";
 
 export interface ArfBrowserTestContext {
@@ -138,7 +139,10 @@ export async function startArfPageTest(
     if (opts.browserFirst) {
       await e2e.launch();
       page = await e2e.newPage(server.httpBaseUrl);
-      await delay(100);
+      // Block until the page's WebSocket is open so the hub has a client
+      // when R starts drawing (the web client only sets `#ws-status.connected`
+      // inside its `onopen` handler — fixed sleeps can resolve before that).
+      await waitForWsConnected(page);
 
       await arf.start();
       await arf.eval(
@@ -149,11 +153,10 @@ export async function startArfPageTest(
       await arf.eval(
         `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
       );
-      await delay(100);
 
       await e2e.launch();
       page = await e2e.newPage(server.httpBaseUrl);
-      await delay(300);
+      await waitForWsConnected(page);
     }
 
     return {

--- a/tests/helpers/arf_e2e.ts
+++ b/tests/helpers/arf_e2e.ts
@@ -1,0 +1,175 @@
+import { assert, assertEquals } from "@std/assert";
+import { delay } from "@std/async";
+import { TestServer } from "../../server/tests/helpers/server.ts";
+import { E2EBrowser } from "../../server/tests/helpers/e2e_browser.ts";
+import type { FrameMessage } from "../../server/tests/helpers/types.ts";
+import { AutoMetricsBrowserClient } from "./auto_metrics_client.ts";
+import { pollResize } from "./arf_poll.ts";
+import { ArfSession } from "./arf_session.ts";
+import { toRSocketAddress } from "./r_process.ts";
+
+export interface ArfBrowserTestContext {
+  server: TestServer;
+  browser: AutoMetricsBrowserClient;
+  arf: ArfSession;
+  socketAddr: string;
+  close(): Promise<void>;
+}
+
+export interface ArfPageTestContext {
+  server: TestServer;
+  e2e: E2EBrowser;
+  arf: ArfSession;
+  page: Awaited<ReturnType<E2EBrowser["newPage"]>>;
+  socketAddr: string;
+  close(): Promise<void>;
+}
+
+export async function startArfBrowserTest(): Promise<ArfBrowserTestContext> {
+  const server = new TestServer({ tcp: true });
+  const browser = new AutoMetricsBrowserClient();
+  const arf = new ArfSession();
+
+  await server.start();
+  await browser.connect(server.wsUrl);
+  browser.sendResize(800, 600);
+  await delay(100);
+
+  await arf.start();
+  const socketAddr = toRSocketAddress(server.socketPath);
+  await arf.eval(
+    `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+  );
+
+  return {
+    server,
+    browser,
+    arf,
+    socketAddr,
+    async close() {
+      browser.close();
+      await delay(100);
+      await server.shutdown();
+      server.cleanup();
+      await arf.shutdown();
+    },
+  };
+}
+
+export async function startArfPageTest(
+  opts: { browserFirst: boolean },
+): Promise<ArfPageTestContext> {
+  const server = new TestServer({ tcp: true });
+  const e2e = new E2EBrowser();
+  const arf = new ArfSession();
+
+  await server.start();
+  const socketAddr = toRSocketAddress(server.socketPath);
+  let page: Awaited<ReturnType<E2EBrowser["newPage"]>>;
+
+  if (opts.browserFirst) {
+    await e2e.launch();
+    page = await e2e.newPage(server.httpBaseUrl);
+    await delay(100);
+
+    await arf.start();
+    await arf.eval(
+      `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+    );
+  } else {
+    await arf.start();
+    await arf.eval(
+      `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+    );
+    await delay(100);
+
+    await e2e.launch();
+    page = await e2e.newPage(server.httpBaseUrl);
+    await delay(300);
+  }
+
+  return {
+    server,
+    e2e,
+    arf,
+    page,
+    socketAddr,
+    async close() {
+      await arf.shutdown();
+      await e2e.close();
+      await delay(100);
+      await server.shutdown();
+      server.cleanup();
+    },
+  };
+}
+
+export async function waitForFrameWithOps(
+  browser: AutoMetricsBrowserClient,
+  label: string,
+  timeoutMs = 8000,
+): Promise<FrameMessage> {
+  const frame = await browser.waitForType<FrameMessage>("frame", timeoutMs);
+  assert(frame.plot.ops.length > 0, `${label} should have ops`);
+  return frame;
+}
+
+export async function createTwoBasePlots(
+  ctx: ArfBrowserTestContext,
+): Promise<[FrameMessage, FrameMessage]> {
+  await ctx.arf.eval("plot(1:3); plot(4:6)");
+  const frame1 = await waitForFrameWithOps(ctx.browser, "First frame");
+  const frame2 = await waitForFrameWithOps(ctx.browser, "Second frame");
+  return [frame1, frame2];
+}
+
+export async function waitForResizeFrame(
+  browser: AutoMetricsBrowserClient,
+  timeoutMs = 6000,
+): Promise<FrameMessage> {
+  return await browser.waitForMessage<FrameMessage>(
+    (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+    timeoutMs,
+  );
+}
+
+export async function sendResizeAndPoll(
+  ctx: ArfBrowserTestContext,
+  width: number,
+  height: number,
+): Promise<void> {
+  ctx.browser.sendResize(width, height);
+  await ctx.browser.sendPing(3000);
+  await pollResize(ctx.arf, 40);
+}
+
+export async function sendPlotIndexResizeAndPoll(
+  ctx: ArfBrowserTestContext,
+  width: number,
+  height: number,
+  plotIndex: number,
+  sessionId?: string,
+): Promise<void> {
+  ctx.browser.sendResizeWithPlotIndex(width, height, plotIndex, sessionId);
+  await ctx.browser.sendPing(3000);
+  await pollResize(ctx.arf, 40);
+}
+
+export async function assertNoExtraFrameBeforePong(
+  browser: AutoMetricsBrowserClient,
+  message: string,
+): Promise<void> {
+  const ac = new AbortController();
+  const sentinel = Symbol("pong");
+  const extraFrame = await Promise.race([
+    browser.waitForType<FrameMessage>("frame", 6000, ac.signal).catch(() =>
+      null
+    ),
+    browser.sendPing(3000).then(() => {
+      ac.abort();
+      return sentinel;
+    }),
+  ]);
+
+  assertEquals(extraFrame, sentinel, message);
+}

--- a/tests/helpers/arf_e2e.ts
+++ b/tests/helpers/arf_e2e.ts
@@ -25,35 +25,66 @@ export interface ArfPageTestContext {
   close(): Promise<void>;
 }
 
+async function closeArfBrowserResources(
+  server: TestServer,
+  browser: AutoMetricsBrowserClient,
+  arf: ArfSession,
+): Promise<void> {
+  browser.close();
+  await delay(100);
+  try {
+    await server.shutdown();
+  } finally {
+    server.cleanup();
+    await arf.shutdown();
+  }
+}
+
+async function closeArfPageResources(
+  server: TestServer,
+  e2e: E2EBrowser,
+  arf: ArfSession,
+): Promise<void> {
+  await arf.shutdown();
+  await e2e.close();
+  await delay(100);
+  try {
+    await server.shutdown();
+  } finally {
+    server.cleanup();
+  }
+}
+
 export async function startArfBrowserTest(): Promise<ArfBrowserTestContext> {
   const server = new TestServer({ tcp: true });
   const browser = new AutoMetricsBrowserClient();
   const arf = new ArfSession();
 
-  await server.start();
-  await browser.connect(server.wsUrl);
-  browser.sendResize(800, 600);
-  await delay(100);
+  try {
+    await server.start();
+    await browser.connect(server.wsUrl);
+    browser.sendResize(800, 600);
+    await delay(100);
 
-  await arf.start();
-  const socketAddr = toRSocketAddress(server.socketPath);
-  await arf.eval(
-    `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
-  );
+    await arf.start();
+    const socketAddr = toRSocketAddress(server.socketPath);
+    await arf.eval(
+      `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+    );
 
-  return {
-    server,
-    browser,
-    arf,
-    socketAddr,
-    async close() {
-      browser.close();
-      await delay(100);
-      await server.shutdown();
-      server.cleanup();
-      await arf.shutdown();
-    },
-  };
+    return {
+      server,
+      browser,
+      arf,
+      socketAddr,
+      async close() {
+        await closeArfBrowserResources(server, browser, arf);
+      },
+    };
+  } catch (error) {
+    await closeArfBrowserResources(server, browser, arf);
+    throw error;
+  }
 }
 
 export async function startArfPageTest(
@@ -63,45 +94,46 @@ export async function startArfPageTest(
   const e2e = new E2EBrowser();
   const arf = new ArfSession();
 
-  await server.start();
-  const socketAddr = toRSocketAddress(server.socketPath);
-  let page: Awaited<ReturnType<E2EBrowser["newPage"]>>;
+  try {
+    await server.start();
+    const socketAddr = toRSocketAddress(server.socketPath);
+    let page: Awaited<ReturnType<E2EBrowser["newPage"]>>;
 
-  if (opts.browserFirst) {
-    await e2e.launch();
-    page = await e2e.newPage(server.httpBaseUrl);
-    await delay(100);
-
-    await arf.start();
-    await arf.eval(
-      `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
-    );
-  } else {
-    await arf.start();
-    await arf.eval(
-      `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
-    );
-    await delay(100);
-
-    await e2e.launch();
-    page = await e2e.newPage(server.httpBaseUrl);
-    await delay(300);
-  }
-
-  return {
-    server,
-    e2e,
-    arf,
-    page,
-    socketAddr,
-    async close() {
-      await arf.shutdown();
-      await e2e.close();
+    if (opts.browserFirst) {
+      await e2e.launch();
+      page = await e2e.newPage(server.httpBaseUrl);
       await delay(100);
-      await server.shutdown();
-      server.cleanup();
-    },
-  };
+
+      await arf.start();
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+    } else {
+      await arf.start();
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+      await delay(100);
+
+      await e2e.launch();
+      page = await e2e.newPage(server.httpBaseUrl);
+      await delay(300);
+    }
+
+    return {
+      server,
+      e2e,
+      arf,
+      page,
+      socketAddr,
+      async close() {
+        await closeArfPageResources(server, e2e, arf);
+      },
+    };
+  } catch (error) {
+    await closeArfPageResources(server, e2e, arf);
+    throw error;
+  }
 }
 
 export async function waitForFrameWithOps(

--- a/tests/helpers/arf_e2e.ts
+++ b/tests/helpers/arf_e2e.ts
@@ -91,9 +91,14 @@ export async function startArfBrowserTest(): Promise<ArfBrowserTestContext> {
 
   try {
     await server.start();
+    // Connect the browser before the R session registers, so the hub has a
+    // client to forward initial frames to. We deliberately do NOT send an
+    // initial resize here: the hub only forwards resize messages to currently
+    // registered R sessions, and `arf.start()` does not register one — that
+    // happens later when `jgd(...)` opens the socket — so any resize sent
+    // before then is silently dropped. `jgd(width=8, height=6, dpi=96)` below
+    // sets the device size authoritatively from R's side.
     await browser.connect(server.wsUrl);
-    browser.sendResize(800, 600);
-    await delay(100);
 
     await arf.start();
     const socketAddr = toRSocketAddress(server.socketPath);

--- a/tests/helpers/arf_poll.ts
+++ b/tests/helpers/arf_poll.ts
@@ -4,8 +4,15 @@ export async function pollResize(
   arf: ArfSession,
   iterations = 120,
 ): Promise<void> {
+  if (!Number.isInteger(iterations) || iterations < 0) {
+    throw new Error(
+      `pollResize: iterations must be a non-negative integer, got ${iterations}`,
+    );
+  }
+  // seq_len() yields integer(0) for 0, so the loop body never runs.
+  // (Note: 1:0 in R would unexpectedly produce c(1, 0) and run twice.)
   await arf.eval(
-    `for (i in 1:${iterations}) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }`,
+    `for (i in seq_len(${iterations})) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }`,
     60_000,
   );
 }

--- a/tests/helpers/arf_poll.ts
+++ b/tests/helpers/arf_poll.ts
@@ -1,0 +1,11 @@
+import type { ArfSession } from "./arf_session.ts";
+
+export async function pollResize(
+  arf: ArfSession,
+  iterations = 120,
+): Promise<void> {
+  await arf.eval(
+    `for (i in 1:${iterations}) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }`,
+    60_000,
+  );
+}

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -14,6 +14,7 @@ export interface ArfEvalResult {
 }
 
 export class ArfSession {
+  #starting = false;
   #process: Deno.ChildProcess | null = null;
   #pid: number | null = null;
   #tempLogFile: string | null = null;
@@ -28,9 +29,10 @@ export class ArfSession {
   async start(
     opts: { timeoutMs?: number; logFile?: string } = {},
   ): Promise<void> {
-    if (this.#process !== null || this.#pid !== null) {
+    if (this.#starting || this.#process !== null || this.#pid !== null) {
       throw new Error("ArfSession already started");
     }
+    this.#starting = true;
 
     const { timeoutMs = 30_000 } = opts;
     const logFile = opts.logFile ??
@@ -48,6 +50,7 @@ export class ArfSession {
       process = cmd.spawn();
     } catch (error) {
       await this.#removeTempLogFile();
+      this.#starting = false;
       throw error;
     }
 
@@ -70,10 +73,11 @@ export class ArfSession {
     } catch (error) {
       // If startup fails after spawn (timeout/invalid ready JSON), ensure
       // the child is torn down so it cannot leak into later tests.
-      await this.shutdown();
+      await this.#cleanupStartupProcess(process, logFile);
       throw error;
     } finally {
       if (timeoutId !== undefined) clearTimeout(timeoutId);
+      this.#starting = false;
     }
   }
 
@@ -166,6 +170,7 @@ export class ArfSession {
     this.#pid = null;
     this.#process = null;
     this.#tempLogFile = null;
+    this.#starting = false;
     this.#startupId++;
 
     if (process === null) {
@@ -232,6 +237,35 @@ export class ArfSession {
         // already reaped or unavailable
       }
     }
+  }
+
+  async #cleanupStartupProcess(
+    process: Deno.ChildProcess,
+    logFile: string,
+  ): Promise<void> {
+    if (this.#process === process) {
+      this.#pid = null;
+      this.#process = null;
+      this.#tempLogFile = null;
+      this.#startupId++;
+    }
+
+    try {
+      process.kill("SIGKILL");
+    } catch {
+      // already exited
+    }
+    try {
+      await process.status;
+    } catch {
+      // ignore
+    }
+    try {
+      await process.stdout.cancel();
+    } catch {
+      // already closed
+    }
+    await this.#removeLogFile(logFile);
   }
 
   async #removeTempLogFile(): Promise<void> {

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -17,6 +17,7 @@ export class ArfSession {
   #process: Deno.ChildProcess | null = null;
   #pid: number | null = null;
   #tempLogFile: string | null = null;
+  #startupId = 0;
 
   /**
    * Start an arf headless session and wait until R is ready for IPC.
@@ -27,6 +28,10 @@ export class ArfSession {
   async start(
     opts: { timeoutMs?: number; logFile?: string } = {},
   ): Promise<void> {
+    if (this.#process !== null || this.#pid !== null) {
+      throw new Error("ArfSession already started");
+    }
+
     const { timeoutMs = 30_000 } = opts;
     const logFile = opts.logFile ??
       await Deno.makeTempFile({ prefix: "arf-", suffix: ".log" });
@@ -38,7 +43,16 @@ export class ArfSession {
       stderr: "null",
     });
 
-    this.#process = cmd.spawn();
+    let process: Deno.ChildProcess;
+    try {
+      process = cmd.spawn();
+    } catch (error) {
+      await this.#removeTempLogFile();
+      throw error;
+    }
+
+    this.#process = process;
+    const startupId = ++this.#startupId;
 
     let timeoutId: number | undefined;
     const timeout = new Promise<never>((_, reject) => {
@@ -52,7 +66,7 @@ export class ArfSession {
     });
 
     try {
-      await Promise.race([this.#readReadyJson(), timeout]);
+      await Promise.race([this.#readReadyJson(process, startupId), timeout]);
     } catch (error) {
       // If startup fails after spawn (timeout/invalid ready JSON), ensure
       // the child is torn down so it cannot leak into later tests.
@@ -63,8 +77,11 @@ export class ArfSession {
     }
   }
 
-  async #readReadyJson(): Promise<void> {
-    const reader = this.#process!.stdout.getReader();
+  async #readReadyJson(
+    process: Deno.ChildProcess,
+    startupId: number,
+  ): Promise<void> {
+    const reader = process.stdout.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
     try {
@@ -80,6 +97,9 @@ export class ArfSession {
           buffer = buffer.slice(nl + 1);
           if (line) {
             const info = JSON.parse(line) as { pid: number };
+            if (this.#process !== process || this.#startupId !== startupId) {
+              throw new Error("arf headless startup was aborted");
+            }
             this.#pid = info.pid;
             return;
           }
@@ -146,14 +166,11 @@ export class ArfSession {
     this.#pid = null;
     this.#process = null;
     this.#tempLogFile = null;
+    this.#startupId++;
 
     if (process === null) {
       if (tempLogFile !== null) {
-        try {
-          await Deno.remove(tempLogFile);
-        } catch {
-          // already removed or inaccessible
-        }
+        await this.#removeLogFile(tempLogFile);
       }
       return;
     }
@@ -166,15 +183,7 @@ export class ArfSession {
 
     try {
       if (pid !== null) {
-        try {
-          await new Deno.Command("arf", {
-            args: ["ipc", "shutdown", "--pid", String(pid)],
-            stdout: "null",
-            stderr: "null",
-          }).output();
-        } catch {
-          // ignore — fallback kill above
-        }
+        await this.#shutdownByIpc(pid, 5_000);
       }
       await process.status;
     } catch {
@@ -187,12 +196,55 @@ export class ArfSession {
         // already closed
       }
       if (tempLogFile !== null) {
-        try {
-          await Deno.remove(tempLogFile);
-        } catch {
-          // already removed or inaccessible
-        }
+        await this.#removeLogFile(tempLogFile);
       }
+    }
+  }
+
+  async #shutdownByIpc(pid: number, timeoutMs: number): Promise<void> {
+    const shutdown = new Deno.Command("arf", {
+      args: ["ipc", "shutdown", "--pid", String(pid)],
+      stdout: "null",
+      stderr: "null",
+    }).spawn();
+
+    let timeoutId: number | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        try {
+          shutdown.kill("SIGKILL");
+        } catch { /* already exited */ }
+        reject(
+          new Error(`arf ipc shutdown timed out after ${timeoutMs}ms`),
+        );
+      }, timeoutMs);
+    });
+
+    try {
+      await Promise.race([shutdown.status, timeout]);
+    } catch {
+      // ignore — headless process fallback kill is handled by shutdown()
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      try {
+        await shutdown.status;
+      } catch {
+        // already reaped or unavailable
+      }
+    }
+  }
+
+  async #removeTempLogFile(): Promise<void> {
+    const tempLogFile = this.#tempLogFile;
+    this.#tempLogFile = null;
+    if (tempLogFile !== null) await this.#removeLogFile(tempLogFile);
+  }
+
+  async #removeLogFile(path: string): Promise<void> {
+    try {
+      await Deno.remove(path);
+    } catch {
+      // already removed or inaccessible
     }
   }
 

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -107,6 +107,11 @@ export class ArfSession {
             if (this.#process !== process || this.#startupId !== startupId) {
               throw new Error("arf headless startup was aborted");
             }
+            if (!Number.isFinite(info.pid)) {
+              throw new Error(
+                `arf headless ready JSON did not contain a numeric pid: ${line}`,
+              );
+            }
             this.#pid = info.pid;
             return;
           }
@@ -301,7 +306,7 @@ export class ArfSession {
 }
 
 /**
- * Convenience wrapper for use with `ignore: !arfTestAvailable` in Deno.test.
+ * Check only the `arf` binary/version. Use checkArfTestAvailable() for tests.
  */
 export async function checkArfAvailable(): Promise<boolean> {
   if (!await ArfSession.isAvailable()) return false;

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -51,6 +51,11 @@ export class ArfSession {
 
     try {
       await Promise.race([this.#readReadyJson(), timeout]);
+    } catch (error) {
+      // If startup fails after spawn (timeout/invalid ready JSON), ensure
+      // the child is torn down so it cannot leak into later tests.
+      await this.shutdown();
+      throw error;
     } finally {
       if (timeoutId !== undefined) clearTimeout(timeoutId);
     }

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -93,13 +93,18 @@ export class ArfSession {
   /**
    * Evaluate R code in the session.
    *
-   * R evaluation errors are returned in `result.error` (exit code 0).
-   * Throws only on IPC/transport failures (non-zero exit code).
+   * By default, throws on both IPC failures and R evaluation errors.
+   * Set opts.throwOnRError=false to inspect result.error manually.
    *
    * @param code      R code to evaluate
    * @param timeoutMs IPC response timeout in ms (default: 30000)
    */
-  async eval(code: string, timeoutMs = 30_000): Promise<ArfEvalResult> {
+  async eval(
+    code: string,
+    timeoutMs = 30_000,
+    opts: { throwOnRError?: boolean } = {},
+  ): Promise<ArfEvalResult> {
+    const { throwOnRError = true } = opts;
     if (this.#pid === null) throw new Error("ArfSession not started");
 
     const cmd = new Deno.Command("arf", {
@@ -122,7 +127,13 @@ export class ArfSession {
       throw new Error(`arf ipc eval failed (exit ${output.code}): ${stderr}`);
     }
 
-    return JSON.parse(new TextDecoder().decode(output.stdout)) as ArfEvalResult;
+    const result = JSON.parse(
+      new TextDecoder().decode(output.stdout),
+    ) as ArfEvalResult;
+    if (throwOnRError && result.error !== null) {
+      throw new Error(`R eval failed: ${result.error}`);
+    }
+    return result;
   }
 
   /**

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -4,6 +4,7 @@
  * Wraps `arf headless` + `arf ipc eval/shutdown` to enable step-by-step
  * R command injection between browser interactions.
  */
+import { checkRAvailable } from "./r_process.ts";
 
 export interface ArfEvalResult {
   stdout: string | null;
@@ -126,16 +127,18 @@ export class ArfSession {
     this.#pid = null;
     this.#process = null;
 
-    if (pid === null || process === null) return;
+    if (process === null) return;
 
-    try {
-      await new Deno.Command("arf", {
-        args: ["ipc", "shutdown", "--pid", String(pid)],
-        stdout: "null",
-        stderr: "null",
-      }).output();
-    } catch {
-      // ignore — fallback kill below
+    if (pid !== null) {
+      try {
+        await new Deno.Command("arf", {
+          args: ["ipc", "shutdown", "--pid", String(pid)],
+          stdout: "null",
+          stderr: "null",
+        }).output();
+      } catch {
+        // ignore — fallback kill below
+      }
     }
 
     const timeoutId = setTimeout(() => {
@@ -174,9 +177,13 @@ export class ArfSession {
 }
 
 /**
- * Convenience wrapper for use with `ignore: !arfAvailable` in Deno.test.
- * Call once at module level alongside checkRAvailable().
+ * Convenience wrapper for use with `ignore: !arfTestAvailable` in Deno.test.
  */
 export async function checkArfAvailable(): Promise<boolean> {
   return ArfSession.isAvailable();
+}
+
+/** True when tests can run via arf (arf binary + R + jgd package available). */
+export async function checkArfTestAvailable(): Promise<boolean> {
+  return await checkArfAvailable() && await checkRAvailable();
 }

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -34,49 +34,52 @@ export class ArfSession {
     }
     this.#starting = true;
 
-    const { timeoutMs = 30_000 } = opts;
-    const logFile = opts.logFile ??
-      await Deno.makeTempFile({ prefix: "arf-", suffix: ".log" });
-    this.#tempLogFile = opts.logFile ? null : logFile;
-
-    const cmd = new Deno.Command("arf", {
-      args: ["headless", "--json", "--log-file", logFile],
-      stdout: "piped",
-      stderr: "null",
-    });
-
-    let process: Deno.ChildProcess;
     try {
-      process = cmd.spawn();
-    } catch (error) {
-      await this.#removeTempLogFile();
-      this.#starting = false;
-      throw error;
-    }
+      const { timeoutMs = 30_000 } = opts;
+      const logFile = opts.logFile ??
+        await Deno.makeTempFile({ prefix: "arf-", suffix: ".log" });
+      const tempLogFile = opts.logFile ? null : logFile;
+      this.#tempLogFile = tempLogFile;
 
-    this.#process = process;
-    const startupId = ++this.#startupId;
+      const cmd = new Deno.Command("arf", {
+        args: ["headless", "--json", "--log-file", logFile],
+        stdout: "piped",
+        stderr: "null",
+      });
 
-    let timeoutId: number | undefined;
-    const timeout = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(
-        () =>
-          reject(
-            new Error(`arf headless startup timed out after ${timeoutMs}ms`),
-          ),
-        timeoutMs,
-      );
-    });
+      let process: Deno.ChildProcess;
+      try {
+        process = cmd.spawn();
+      } catch (error) {
+        await this.#removeTempLogFile();
+        throw error;
+      }
 
-    try {
-      await Promise.race([this.#readReadyJson(process, startupId), timeout]);
-    } catch (error) {
-      // If startup fails after spawn (timeout/invalid ready JSON), ensure
-      // the child is torn down so it cannot leak into later tests.
-      await this.#cleanupStartupProcess(process, logFile);
-      throw error;
+      this.#process = process;
+      const startupId = ++this.#startupId;
+
+      let timeoutId: number | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () =>
+            reject(
+              new Error(`arf headless startup timed out after ${timeoutMs}ms`),
+            ),
+          timeoutMs,
+        );
+      });
+
+      try {
+        await Promise.race([this.#readReadyJson(process, startupId), timeout]);
+      } catch (error) {
+        // If startup fails after spawn (timeout/invalid ready JSON), ensure
+        // the child is torn down so it cannot leak into later tests.
+        await this.#cleanupStartupProcess(process, tempLogFile);
+        throw error;
+      } finally {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+      }
     } finally {
-      if (timeoutId !== undefined) clearTimeout(timeoutId);
       this.#starting = false;
     }
   }
@@ -241,7 +244,7 @@ export class ArfSession {
 
   async #cleanupStartupProcess(
     process: Deno.ChildProcess,
-    logFile: string,
+    tempLogFile: string | null,
   ): Promise<void> {
     if (this.#process === process) {
       this.#pid = null;
@@ -265,7 +268,7 @@ export class ArfSession {
     } catch {
       // already closed
     }
-    await this.#removeLogFile(logFile);
+    if (tempLogFile !== null) await this.#removeLogFile(tempLogFile);
   }
 
   async #removeTempLogFile(): Promise<void> {

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -1,0 +1,182 @@
+/**
+ * arf headless session manager for E2E tests.
+ *
+ * Wraps `arf headless` + `arf ipc eval/shutdown` to enable step-by-step
+ * R command injection between browser interactions.
+ */
+
+export interface ArfEvalResult {
+  stdout: string | null;
+  stderr: string | null;
+  value: string | null;
+  error: string | null;
+}
+
+export class ArfSession {
+  #process: Deno.ChildProcess | null = null;
+  #pid: number | null = null;
+
+  /**
+   * Start an arf headless session and wait until R is ready for IPC.
+   *
+   * @param opts.timeoutMs Startup timeout in ms (default: 30000)
+   * @param opts.logFile   Path for arf log output (default: OS temp file)
+   */
+  async start(
+    opts: { timeoutMs?: number; logFile?: string } = {},
+  ): Promise<void> {
+    const { timeoutMs = 30_000 } = opts;
+    const logFile = opts.logFile ??
+      await Deno.makeTempFile({ prefix: "arf-", suffix: ".log" });
+
+    const cmd = new Deno.Command("arf", {
+      args: ["headless", "--json", "--log-file", logFile],
+      stdout: "piped",
+      stderr: "null",
+    });
+
+    this.#process = cmd.spawn();
+
+    let timeoutId: number | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () =>
+          reject(
+            new Error(`arf headless startup timed out after ${timeoutMs}ms`),
+          ),
+        timeoutMs,
+      );
+    });
+
+    try {
+      await Promise.race([this.#readReadyJson(), timeout]);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
+  }
+
+  async #readReadyJson(): Promise<void> {
+    const reader = this.#process!.stdout.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          throw new Error("arf headless exited before printing ready JSON");
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const nl = buffer.indexOf("\n");
+        if (nl !== -1) {
+          const line = buffer.slice(0, nl).trim();
+          buffer = buffer.slice(nl + 1);
+          if (line) {
+            const info = JSON.parse(line) as { pid: number };
+            this.#pid = info.pid;
+            return;
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  /**
+   * Evaluate R code in the session.
+   *
+   * R evaluation errors are returned in `result.error` (exit code 0).
+   * Throws only on IPC/transport failures (non-zero exit code).
+   *
+   * @param code      R code to evaluate
+   * @param timeoutMs IPC response timeout in ms (default: 30000)
+   */
+  async eval(code: string, timeoutMs = 30_000): Promise<ArfEvalResult> {
+    if (this.#pid === null) throw new Error("ArfSession not started");
+
+    const cmd = new Deno.Command("arf", {
+      args: [
+        "ipc",
+        "eval",
+        "--pid",
+        String(this.#pid),
+        "--timeout",
+        String(timeoutMs),
+        code,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await cmd.output();
+    if (!output.success) {
+      const stderr = new TextDecoder().decode(output.stderr);
+      throw new Error(`arf ipc eval failed (exit ${output.code}): ${stderr}`);
+    }
+
+    return JSON.parse(new TextDecoder().decode(output.stdout)) as ArfEvalResult;
+  }
+
+  /**
+   * Shut down the arf session gracefully, with SIGKILL fallback after 5s.
+   */
+  async shutdown(): Promise<void> {
+    const pid = this.#pid;
+    const process = this.#process;
+    this.#pid = null;
+    this.#process = null;
+
+    if (pid === null || process === null) return;
+
+    try {
+      await new Deno.Command("arf", {
+        args: ["ipc", "shutdown", "--pid", String(pid)],
+        stdout: "null",
+        stderr: "null",
+      }).output();
+    } catch {
+      // ignore — fallback kill below
+    }
+
+    const timeoutId = setTimeout(() => {
+      try {
+        process.kill("SIGKILL");
+      } catch { /* already exited */ }
+    }, 5_000);
+
+    try {
+      await process.status;
+    } catch {
+      // ignore
+    } finally {
+      clearTimeout(timeoutId);
+      try {
+        await process.stdout.cancel();
+      } catch {
+        // already closed
+      }
+    }
+  }
+
+  /** Return true if the `arf` binary is available on this system. */
+  static async isAvailable(): Promise<boolean> {
+    try {
+      const output = await new Deno.Command("arf", {
+        args: ["--version"],
+        stdout: "null",
+        stderr: "null",
+      }).output();
+      return output.success;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Convenience wrapper for use with `ignore: !arfAvailable` in Deno.test.
+ * Call once at module level alongside checkRAvailable().
+ */
+export async function checkArfAvailable(): Promise<boolean> {
+  return ArfSession.isAvailable();
+}

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -106,7 +106,15 @@ export class ArfSession {
           const line = buffer.slice(0, nl).trim();
           buffer = buffer.slice(nl + 1);
           if (!line) continue;
-          const info = JSON.parse(line) as { pid: number };
+          let info: { pid: number };
+          try {
+            info = JSON.parse(line) as { pid: number };
+          } catch (error) {
+            throw new Error(
+              `arf headless ready JSON was invalid: ${line}`,
+              { cause: error },
+            );
+          }
           if (this.#process !== process || this.#startupId !== startupId) {
             throw new Error("arf headless startup was aborted");
           }

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -136,7 +136,16 @@ export class ArfSession {
     this.#process = null;
     this.#tempLogFile = null;
 
-    if (process === null) return;
+    if (process === null) {
+      if (tempLogFile !== null) {
+        try {
+          await Deno.remove(tempLogFile);
+        } catch {
+          // already removed or inaccessible
+        }
+      }
+      return;
+    }
 
     const timeoutId = setTimeout(() => {
       try {

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -194,10 +194,20 @@ export class ArfSession {
       } catch { /* already exited */ }
     }, 5_000);
 
-    try {
-      if (pid !== null) {
+    if (pid !== null) {
+      try {
         await this.#shutdownByIpc(pid, 5_000);
+      } catch {
+        // IPC shutdown could not even be initiated (e.g. `arf` binary
+        // missing). Kill the headless process directly so it does not
+        // outlive this call when the SIGKILL fallback is cleared below.
+        try {
+          process.kill("SIGKILL");
+        } catch { /* already exited */ }
       }
+    }
+
+    try {
       await process.status;
     } catch {
       // ignore

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -16,6 +16,7 @@ export interface ArfEvalResult {
 export class ArfSession {
   #process: Deno.ChildProcess | null = null;
   #pid: number | null = null;
+  #tempLogFile: string | null = null;
 
   /**
    * Start an arf headless session and wait until R is ready for IPC.
@@ -29,6 +30,7 @@ export class ArfSession {
     const { timeoutMs = 30_000 } = opts;
     const logFile = opts.logFile ??
       await Deno.makeTempFile({ prefix: "arf-", suffix: ".log" });
+    this.#tempLogFile = opts.logFile ? null : logFile;
 
     const cmd = new Deno.Command("arf", {
       args: ["headless", "--json", "--log-file", logFile],
@@ -129,22 +131,12 @@ export class ArfSession {
   async shutdown(): Promise<void> {
     const pid = this.#pid;
     const process = this.#process;
+    const tempLogFile = this.#tempLogFile;
     this.#pid = null;
     this.#process = null;
+    this.#tempLogFile = null;
 
     if (process === null) return;
-
-    if (pid !== null) {
-      try {
-        await new Deno.Command("arf", {
-          args: ["ipc", "shutdown", "--pid", String(pid)],
-          stdout: "null",
-          stderr: "null",
-        }).output();
-      } catch {
-        // ignore — fallback kill below
-      }
-    }
 
     const timeoutId = setTimeout(() => {
       try {
@@ -153,6 +145,17 @@ export class ArfSession {
     }, 5_000);
 
     try {
+      if (pid !== null) {
+        try {
+          await new Deno.Command("arf", {
+            args: ["ipc", "shutdown", "--pid", String(pid)],
+            stdout: "null",
+            stderr: "null",
+          }).output();
+        } catch {
+          // ignore — fallback kill above
+        }
+      }
       await process.status;
     } catch {
       // ignore
@@ -162,6 +165,13 @@ export class ArfSession {
         await process.stdout.cancel();
       } catch {
         // already closed
+      }
+      if (tempLogFile !== null) {
+        try {
+          await Deno.remove(tempLogFile);
+        } catch {
+          // already removed or inaccessible
+        }
       }
     }
   }
@@ -185,7 +195,24 @@ export class ArfSession {
  * Convenience wrapper for use with `ignore: !arfTestAvailable` in Deno.test.
  */
 export async function checkArfAvailable(): Promise<boolean> {
-  return ArfSession.isAvailable();
+  if (!await ArfSession.isAvailable()) return false;
+  try {
+    const output = await new Deno.Command("arf", {
+      args: ["--version"],
+      stdout: "piped",
+      stderr: "null",
+    }).output();
+    if (!output.success) return false;
+    const versionText = new TextDecoder().decode(output.stdout);
+    const match = versionText.match(/(\d+)\.(\d+)\.(\d+)/);
+    if (!match) return false;
+    const [major, minor, patch] = match.slice(1).map((x) => Number(x));
+    if (major > 0) return true;
+    if (minor > 3) return true;
+    return minor === 3 && patch >= 0;
+  } catch {
+    return false;
+  }
 }
 
 /** True when tests can run via arf (arf binary + R + jgd package available). */

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -98,23 +98,25 @@ export class ArfSession {
           throw new Error("arf headless exited before printing ready JSON");
         }
         buffer += decoder.decode(value, { stream: true });
-        const nl = buffer.indexOf("\n");
-        if (nl !== -1) {
+        // Drain every complete line in this chunk before reading again — a
+        // single read() can return a blank line and the ready JSON together,
+        // and pausing for another read after only the blank would hang.
+        let nl: number;
+        while ((nl = buffer.indexOf("\n")) !== -1) {
           const line = buffer.slice(0, nl).trim();
           buffer = buffer.slice(nl + 1);
-          if (line) {
-            const info = JSON.parse(line) as { pid: number };
-            if (this.#process !== process || this.#startupId !== startupId) {
-              throw new Error("arf headless startup was aborted");
-            }
-            if (!Number.isFinite(info.pid)) {
-              throw new Error(
-                `arf headless ready JSON did not contain a numeric pid: ${line}`,
-              );
-            }
-            this.#pid = info.pid;
-            return;
+          if (!line) continue;
+          const info = JSON.parse(line) as { pid: number };
+          if (this.#process !== process || this.#startupId !== startupId) {
+            throw new Error("arf headless startup was aborted");
           }
+          if (!Number.isFinite(info.pid)) {
+            throw new Error(
+              `arf headless ready JSON did not contain a numeric pid: ${line}`,
+            );
+          }
+          this.#pid = info.pid;
+          return;
         }
       }
     } finally {

--- a/tests/helpers/auto_metrics_client.ts
+++ b/tests/helpers/auto_metrics_client.ts
@@ -75,7 +75,12 @@ export class AutoMetricsBrowserClient {
   }
 
   /** Send a resize message with plotIndex for historical plot resizing. */
-  sendResizeWithPlotIndex(width: number, height: number, plotIndex: number, sessionId?: string): void {
+  sendResizeWithPlotIndex(
+    width: number,
+    height: number,
+    plotIndex: number,
+    sessionId?: string,
+  ): void {
     this.#inner.sendResizeWithPlotIndex(width, height, plotIndex, sessionId);
   }
 

--- a/tests/helpers/page_ready.ts
+++ b/tests/helpers/page_ready.ts
@@ -1,0 +1,31 @@
+import { delay } from "@std/async";
+import type { E2EBrowser } from "../../server/tests/helpers/e2e_browser.ts";
+
+type Page = Awaited<ReturnType<E2EBrowser["newPage"]>>;
+
+/**
+ * Wait until the page's WebSocket has opened (the web client sets
+ * `#ws-status.className = 'connected'` in its `ws.onopen` handler).
+ *
+ * Replaces fixed `await delay(...)` calls that were used as a proxy for
+ * "the page is connected"; under slow CI those fixed waits can resolve
+ * before `onopen` fires, causing initial frames to be lost.
+ */
+export async function waitForWsConnected(
+  page: Page,
+  timeoutMs = 10_000,
+  pollMs = 50,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const connected = await page.evaluate(`(function() {
+      var el = document.getElementById('ws-status');
+      return !!el && el.className === 'connected';
+    })()`) as boolean;
+    if (connected) return;
+    await delay(pollMs);
+  }
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for #ws-status.connected`,
+  );
+}

--- a/tests/helpers/plot_settle.ts
+++ b/tests/helpers/plot_settle.ts
@@ -1,0 +1,23 @@
+import { delay } from "@std/async";
+import {
+  type E2EBrowser,
+  plotInfoText,
+} from "../../server/tests/helpers/e2e_browser.ts";
+
+export async function assertPlotInfoStable(
+  page: Awaited<ReturnType<E2EBrowser["newPage"]>>,
+  expected: string,
+  quietMs = 1_500,
+  pollMs = 100,
+): Promise<void> {
+  const deadline = Date.now() + quietMs;
+  while (Date.now() < deadline) {
+    const info = await plotInfoText(page);
+    if (info !== expected) {
+      throw new Error(
+        `plotInfo changed during quiet window: expected "${expected}", got "${info}"`,
+      );
+    }
+    await delay(pollMs);
+  }
+}

--- a/tests/helpers/plot_settle.ts
+++ b/tests/helpers/plot_settle.ts
@@ -11,13 +11,15 @@ export async function assertPlotInfoStable(
   pollMs = 100,
 ): Promise<void> {
   const deadline = Date.now() + quietMs;
-  while (Date.now() < deadline) {
+  while (true) {
     const info = await plotInfoText(page);
     if (info !== expected) {
       throw new Error(
         `plotInfo changed during quiet window: expected "${expected}", got "${info}"`,
       );
     }
-    await delay(pollMs);
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+    await delay(Math.min(pollMs, remainingMs));
   }
 }

--- a/tests/helpers/r_packages.ts
+++ b/tests/helpers/r_packages.ts
@@ -1,0 +1,14 @@
+export async function checkGgplot2Available(): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command("Rscript", {
+      args: ["-e", 'library(ggplot2); cat("ok")'],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const output = await cmd.output();
+    const stdout = new TextDecoder().decode(output.stdout);
+    return output.success && stdout.includes("ok");
+  } catch {
+    return false;
+  }
+}

--- a/tests/helpers/r_process.ts
+++ b/tests/helpers/r_process.ts
@@ -1,14 +1,6 @@
 /**
- * R subprocess manager for E2E tests.
- * Spawns Rscript with plotting commands that use the real jgd device.
+ * R availability and socket helper functions for E2E tests.
  */
-
-export interface RProcessResult {
-  success: boolean;
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-}
 
 /**
  * Translate TestServer's socket path to R's socket address format.
@@ -22,80 +14,6 @@ export function toRSocketAddress(serverSocketPath: string): string {
   // npipe:////./pipe/NAME and Unix socket paths — pass through as-is
   // (R's transport.c understands both formats directly)
   return serverSocketPath;
-}
-
-/**
- * Run an R expression that uses jgd() to produce plots.
- *
- * @param rCode R code to execute (will be wrapped in appropriate setup)
- * @param serverSocketPath Socket path from TestServer (e.g. "tcp:12345" or "/tmp/jgd.sock")
- * @param timeoutMs Maximum time to wait for R process (default 30s)
- */
-export async function runR(
-  rCode: string,
-  serverSocketPath: string,
-  timeoutMs = 30_000,
-): Promise<RProcessResult> {
-  const socketAddr = toRSocketAddress(serverSocketPath);
-
-  // Build the full R expression: load jgd, set socket, run user code
-  const fullCode = `options(jgd.socket = "${socketAddr}"); library(jgd); ${rCode}`;
-
-  const cmd = new Deno.Command("Rscript", {
-    args: ["-e", fullCode],
-    stdout: "piped",
-    stderr: "piped",
-  });
-
-  const process = cmd.spawn();
-
-  // Timeout with SIGKILL fallback
-  const timeoutId = setTimeout(() => {
-    try {
-      process.kill("SIGKILL");
-    } catch {
-      // Already exited
-    }
-  }, timeoutMs);
-
-  try {
-    const output = await process.output();
-    const decoder = new TextDecoder();
-    return {
-      success: output.success,
-      exitCode: output.code,
-      stdout: decoder.decode(output.stdout),
-      stderr: decoder.decode(output.stderr),
-    };
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
-
-/**
- * Start a background R process.  Returns handles to read output and kill it.
- * Unlike runR(), the process stays alive until explicitly killed.
- */
-export function startR(
-  rCode: string,
-  serverSocketPath: string,
-): { process: Deno.ChildProcess; kill: () => void } {
-  const socketAddr = toRSocketAddress(serverSocketPath);
-  const fullCode = `options(jgd.socket = "${socketAddr}"); library(jgd); ${rCode}`;
-
-  const cmd = new Deno.Command("Rscript", {
-    args: ["-e", fullCode],
-    stdout: "piped",
-    stderr: "piped",
-  });
-
-  const process = cmd.spawn();
-  return {
-    process,
-    kill() {
-      try { process.kill("SIGKILL"); } catch { /* already exited */ }
-    },
-  };
 }
 
 /** Check if Rscript is available and the jgd package is installed. */

--- a/tests/helpers/test_log.ts
+++ b/tests/helpers/test_log.ts
@@ -1,0 +1,8 @@
+/**
+ * Timestamped logger for tests.
+ *
+ * Always emits UTC ISO timestamps so CI logs can be compared across runners.
+ */
+export function testLog(message: string): void {
+  console.log(`[test-step] ${new Date().toISOString()} | ${message}`);
+}

--- a/tests/newpage_after_resize_test.ts
+++ b/tests/newpage_after_resize_test.ts
@@ -34,7 +34,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -44,7 +44,7 @@ Deno.test({
       await arf.eval("plot(1:3)");
 
       // Wait for plot 1
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame1.plot.ops.length > 0, "Plot 1 should have ops");
       console.error(
         `frame1: newPage=${frame1.newPage}, resize=${frame1.resize}, ` +
@@ -64,7 +64,7 @@ Deno.test({
       // Collect resize frame first
       while (Date.now() < deadline) {
         try {
-          const frame = await browser.waitForType<FrameMessage>("frame", 5000);
+          const frame = await browser.waitForType<FrameMessage>("frame", 2000);
           allFrames.push(frame);
           if (frame.newPage) plotCount++;
           console.error(
@@ -82,7 +82,7 @@ Deno.test({
 
       while (Date.now() < deadline && plotCount < 2) {
         try {
-          const frame = await browser.waitForType<FrameMessage>("frame", 5000);
+          const frame = await browser.waitForType<FrameMessage>("frame", 2000);
           allFrames.push(frame);
           if (frame.newPage) plotCount++;
           console.error(
@@ -99,7 +99,7 @@ Deno.test({
 
       while (Date.now() < deadline && plotCount < 3) {
         try {
-          const frame = await browser.waitForType<FrameMessage>("frame", 5000);
+          const frame = await browser.waitForType<FrameMessage>("frame", 2000);
           allFrames.push(frame);
           if (frame.newPage) plotCount++;
           console.error(
@@ -113,7 +113,7 @@ Deno.test({
       }
 
       // Wait for trailing frames
-      await delay(1000);
+      await delay(300);
       try {
         const extra = await browser.waitForType<FrameMessage>("frame", 1000);
         allFrames.push(extra);
@@ -183,7 +183,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -193,7 +193,7 @@ Deno.test({
       await arf.eval("plot(1:3)");
 
       // Wait for plot 1
-      const f1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const f1 = await browser.waitForType<FrameMessage>("frame", 8000);
       assertEquals(f1.newPage, true, "First frame must be newPage");
 
       // Send resize after plot 1
@@ -206,7 +206,7 @@ Deno.test({
       const postPlot1Frames: FrameMessage[] = [];
       for (let i = 0; i < 5; i++) {
         try {
-          const f = await browser.waitForType<FrameMessage>("frame", 3000);
+          const f = await browser.waitForType<FrameMessage>("frame", 1500);
           postPlot1Frames.push(f);
           if (f.resize) {
             gotResize1 = true;
@@ -233,7 +233,7 @@ Deno.test({
       await arf.eval("plot(4:6)");
 
       // Wait for plot 2
-      const f2 = await browser.waitForType<FrameMessage>("frame", 10000);
+      const f2 = await browser.waitForType<FrameMessage>("frame", 6000);
       assertEquals(f2.newPage, true, "Plot 2 frame must have newPage");
 
       // Send resize after plot 2
@@ -246,7 +246,7 @@ Deno.test({
       const postPlot2Frames: FrameMessage[] = [];
       for (let i = 0; i < 5; i++) {
         try {
-          const f = await browser.waitForType<FrameMessage>("frame", 3000);
+          const f = await browser.waitForType<FrameMessage>("frame", 1500);
           postPlot2Frames.push(f);
           if (f.resize) {
             gotResize2 = true;
@@ -273,7 +273,7 @@ Deno.test({
       await arf.eval("plot(7:9)");
 
       // Wait for plot 3
-      const f3 = await browser.waitForType<FrameMessage>("frame", 10000);
+      const f3 = await browser.waitForType<FrameMessage>("frame", 6000);
       assertEquals(f3.newPage, true, "Plot 3 frame must have newPage");
     } finally {
       browser.close();

--- a/tests/newpage_after_resize_test.ts
+++ b/tests/newpage_after_resize_test.ts
@@ -36,9 +36,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
 
@@ -186,9 +183,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
 

--- a/tests/newpage_after_resize_test.ts
+++ b/tests/newpage_after_resize_test.ts
@@ -16,11 +16,11 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name: "Real R: resize between plots must not cause duplication",

--- a/tests/newpage_after_resize_test.ts
+++ b/tests/newpage_after_resize_test.ts
@@ -18,6 +18,7 @@ import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
@@ -26,6 +27,7 @@ Deno.test({
   name: "Real R: resize between plots must not cause duplication",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -175,6 +177,7 @@ Deno.test({
     "Real R: resize between each plot must not cause cumulative duplication",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/newpage_after_resize_test.ts
+++ b/tests/newpage_after_resize_test.ts
@@ -16,16 +16,19 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
   name: "Real R: resize between plots must not cause duplication",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -33,116 +36,134 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
-      // Plot 1, then poll for resize, then plot 2, then poll
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); ' +
-          'plot(1:3); ' +
-          'for (i in 1:40) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }; ' +
-          'plot(4:6); ' +
-          'for (i in 1:40) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }; ' +
-          'plot(7:9); ' +
-          'for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
+      await arf.eval("jgd(width=8, height=6, dpi=96)");
+      await arf.eval("plot(1:3)");
+
+      // Wait for plot 1
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame1.plot.ops.length > 0, "Plot 1 should have ops");
+      console.error(
+        `frame1: newPage=${frame1.newPage}, resize=${frame1.resize}, ` +
+          `incremental=${frame1.incremental}, ops=${frame1.plot.ops.length}`,
       );
 
-      try {
-        // Wait for plot 1
-        const frame1 = await browser.waitForType<FrameMessage>(
-          "frame",
-          15000,
-        );
-        assert(frame1.plot.ops.length > 0, "Plot 1 should have ops");
-        console.error(
-          `frame1: newPage=${frame1.newPage}, resize=${frame1.resize}, ` +
-            `incremental=${frame1.incremental}, ops=${frame1.plot.ops.length}`,
-        );
+      // Send a resize with DIFFERENT dimensions to trigger a replay
+      browser.sendResize(640, 480);
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        // Send a resize with DIFFERENT dimensions to trigger a replay
-        browser.sendResize(640, 480);
+      // Collect all frames until we get 3 newPage frames
+      const allFrames: FrameMessage[] = [frame1];
+      const deadline = Date.now() + 20_000;
+      let plotCount = frame1.newPage ? 1 : 0;
 
-        // Collect all frames until we get 3 newPage frames
-        const allFrames: FrameMessage[] = [frame1];
-        const deadline = Date.now() + 20_000;
-        let plotCount = frame1.newPage ? 1 : 0;
-
-        while (Date.now() < deadline && plotCount < 3) {
-          try {
-            const frame = await browser.waitForType<FrameMessage>(
-              "frame",
-              5000,
-            );
-            allFrames.push(frame);
-            if (frame.newPage) plotCount++;
-            console.error(
-              `frame[${allFrames.length - 1}]: newPage=${frame.newPage}, ` +
-                `resize=${frame.resize}, incremental=${frame.incremental}, ` +
-                `ops=${frame.plot.ops.length}`,
-            );
-          } catch {
-            break;
-          }
-        }
-
-        // Wait for trailing frames
-        await delay(1000);
+      // Collect resize frame first
+      while (Date.now() < deadline) {
         try {
-          const extra = await browser.waitForType<FrameMessage>(
-            "frame",
-            1000,
-          );
-          allFrames.push(extra);
+          const frame = await browser.waitForType<FrameMessage>("frame", 5000);
+          allFrames.push(frame);
+          if (frame.newPage) plotCount++;
           console.error(
-            `extra frame: newPage=${extra.newPage}, resize=${extra.resize}, ` +
-              `incremental=${extra.incremental}, ops=${extra.plot.ops.length}`,
+            `frame[${allFrames.length - 1}]: newPage=${frame.newPage}, ` +
+              `resize=${frame.resize}, incremental=${frame.incremental}, ` +
+              `ops=${frame.plot.ops.length}`,
+          );
+          if (frame.resize) break; // got resize frame, now draw plot 2
+        } catch {
+          break;
+        }
+      }
+
+      await arf.eval("plot(4:6)");
+
+      while (Date.now() < deadline && plotCount < 2) {
+        try {
+          const frame = await browser.waitForType<FrameMessage>("frame", 5000);
+          allFrames.push(frame);
+          if (frame.newPage) plotCount++;
+          console.error(
+            `frame[${allFrames.length - 1}]: newPage=${frame.newPage}, ` +
+              `resize=${frame.resize}, incremental=${frame.incremental}, ` +
+              `ops=${frame.plot.ops.length}`,
           );
         } catch {
-          // Expected
+          break;
         }
-
-        // Categorize
-        const newPageFrames = allFrames.filter((f) => f.newPage === true);
-        const resizeFrames = allFrames.filter((f) => f.resize === true);
-        const incrementalFrames = allFrames.filter(
-          (f) => f.incremental === true,
-        );
-        const untaggedFrames = allFrames.filter(
-          (f) => !f.newPage && !f.resize && !f.incremental,
-        );
-
-        console.error(
-          `\nSummary: total=${allFrames.length}, newPage=${newPageFrames.length}, ` +
-            `resize=${resizeFrames.length}, incremental=${incrementalFrames.length}, ` +
-            `untagged=${untaggedFrames.length}`,
-        );
-
-        // Must have exactly 3 newPage frames
-        assertEquals(
-          newPageFrames.length,
-          3,
-          `Expected 3 newPage frames, got ${newPageFrames.length}`,
-        );
-
-        // Should have at least 1 resize frame (from our explicit resize)
-        assert(
-          resizeFrames.length >= 1,
-          `Expected at least 1 resize frame, got ${resizeFrames.length}`,
-        );
-
-        // No untagged complete frames
-        assertEquals(
-          untaggedFrames.length,
-          0,
-          `Untagged complete frames cause duplication: got ${untaggedFrames.length}`,
-        );
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
       }
+
+      await arf.eval("plot(7:9)");
+
+      while (Date.now() < deadline && plotCount < 3) {
+        try {
+          const frame = await browser.waitForType<FrameMessage>("frame", 5000);
+          allFrames.push(frame);
+          if (frame.newPage) plotCount++;
+          console.error(
+            `frame[${allFrames.length - 1}]: newPage=${frame.newPage}, ` +
+              `resize=${frame.resize}, incremental=${frame.incremental}, ` +
+              `ops=${frame.plot.ops.length}`,
+          );
+        } catch {
+          break;
+        }
+      }
+
+      // Wait for trailing frames
+      await delay(1000);
+      try {
+        const extra = await browser.waitForType<FrameMessage>("frame", 1000);
+        allFrames.push(extra);
+        console.error(
+          `extra frame: newPage=${extra.newPage}, resize=${extra.resize}, ` +
+            `incremental=${extra.incremental}, ops=${extra.plot.ops.length}`,
+        );
+      } catch {
+        // Expected
+      }
+
+      // Categorize
+      const newPageFrames = allFrames.filter((f) => f.newPage === true);
+      const resizeFrames = allFrames.filter((f) => f.resize === true);
+      const incrementalFrames = allFrames.filter(
+        (f) => f.incremental === true,
+      );
+      const untaggedFrames = allFrames.filter(
+        (f) => !f.newPage && !f.resize && !f.incremental,
+      );
+
+      console.error(
+        `\nSummary: total=${allFrames.length}, newPage=${newPageFrames.length}, ` +
+          `resize=${resizeFrames.length}, incremental=${incrementalFrames.length}, ` +
+          `untagged=${untaggedFrames.length}`,
+      );
+
+      // Must have exactly 3 newPage frames
+      assertEquals(
+        newPageFrames.length,
+        3,
+        `Expected 3 newPage frames, got ${newPageFrames.length}`,
+      );
+
+      // Should have at least 1 resize frame (from our explicit resize)
+      assert(
+        resizeFrames.length >= 1,
+        `Expected at least 1 resize frame, got ${resizeFrames.length}`,
+      );
+
+      // No untagged complete frames
+      assertEquals(
+        untaggedFrames.length,
+        0,
+        `Untagged complete frames cause duplication: got ${untaggedFrames.length}`,
+      );
     } finally {
       browser.close();
       await delay(100);
+      await arf.shutdown();
       await server.shutdown();
       server.cleanup();
     }
@@ -150,11 +171,13 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Real R: resize between each plot must not cause cumulative duplication",
-  ignore: !rAvailable,
+  name:
+    "Real R: resize between each plot must not cause cumulative duplication",
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -162,110 +185,100 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
-      // Plot 1, then poll, then resize, then poll, then plot 2, etc.
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); ' +
-          'plot(1:3); ' +
-          'for (i in 1:60) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }; ' +
-          'plot(4:6); ' +
-          'for (i in 1:60) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }; ' +
-          'plot(7:9); ' +
-          'for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      await arf.eval(`options(jgd.socket = "${socketAddr}"); library(jgd)`);
+      await arf.eval("jgd(width=8, height=6, dpi=96)");
+      await arf.eval("plot(1:3)");
+
+      // Wait for plot 1
+      const f1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assertEquals(f1.newPage, true, "First frame must be newPage");
+
+      // Send resize after plot 1
+      browser.sendResize(640, 480);
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      // Wait for resize frame
+      let gotResize1 = false;
+      const postPlot1Frames: FrameMessage[] = [];
+      for (let i = 0; i < 5; i++) {
+        try {
+          const f = await browser.waitForType<FrameMessage>("frame", 3000);
+          postPlot1Frames.push(f);
+          if (f.resize) {
+            gotResize1 = true;
+            break;
+          }
+          if (f.newPage) break; // plot 2 arrived before resize
+        } catch {
+          break;
+        }
+      }
+      assert(gotResize1, "Should receive resize frame after plot 1");
+
+      // Count untagged frames between plot 1 and resize
+      const untaggedBetween = postPlot1Frames.filter(
+        (f) => !f.newPage && !f.resize && !f.incremental,
+      );
+      assertEquals(
+        untaggedBetween.length,
+        0,
+        `No untagged frames should appear between plot 1 and plot 2, ` +
+          `got ${untaggedBetween.length}`,
       );
 
-      try {
-        // Wait for plot 1
-        const f1 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assertEquals(f1.newPage, true, "First frame must be newPage");
+      await arf.eval("plot(4:6)");
 
-        // Send resize after plot 1
-        browser.sendResize(640, 480);
+      // Wait for plot 2
+      const f2 = await browser.waitForType<FrameMessage>("frame", 10000);
+      assertEquals(f2.newPage, true, "Plot 2 frame must have newPage");
 
-        // Wait for resize frame
-        let gotResize1 = false;
-        const postPlot1Frames: FrameMessage[] = [];
-        for (let i = 0; i < 5; i++) {
-          try {
-            const f = await browser.waitForType<FrameMessage>("frame", 3000);
-            postPlot1Frames.push(f);
-            if (f.resize) { gotResize1 = true; break; }
-            if (f.newPage) break; // plot 2 arrived before resize
-          } catch {
-            break;
-          }
-        }
-        assert(gotResize1, "Should receive resize frame after plot 1");
+      // Send resize after plot 2
+      browser.sendResize(700, 500);
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        // Wait for plot 2
-        let f2: FrameMessage | null = null;
-        for (const pf of postPlot1Frames) {
-          if (pf.newPage) { f2 = pf; break; }
-        }
-        if (!f2) {
-          f2 = await browser.waitForType<FrameMessage>("frame", 10000);
-        }
-        assertEquals(f2.newPage, true, "Plot 2 frame must have newPage");
-
-        // Count untagged frames between plot 1 and plot 2
-        const untaggedBetween = postPlot1Frames.filter(
-          (f) => !f.newPage && !f.resize && !f.incremental,
-        );
-        assertEquals(
-          untaggedBetween.length,
-          0,
-          `No untagged frames should appear between plot 1 and plot 2, ` +
-            `got ${untaggedBetween.length}`,
-        );
-
-        // Send resize after plot 2
-        browser.sendResize(700, 500);
-
-        // Wait for resize frame
-        let gotResize2 = false;
-        const postPlot2Frames: FrameMessage[] = [];
-        for (let i = 0; i < 5; i++) {
-          try {
-            const f = await browser.waitForType<FrameMessage>("frame", 3000);
-            postPlot2Frames.push(f);
-            if (f.resize) { gotResize2 = true; break; }
-            if (f.newPage) break;
-          } catch {
-            break;
-          }
-        }
-        assert(gotResize2, "Should receive resize frame after plot 2");
-
-        // Wait for plot 3
-        let f3: FrameMessage | null = null;
-        for (const pf of postPlot2Frames) {
-          if (pf.newPage) { f3 = pf; break; }
-        }
-        if (!f3) {
-          f3 = await browser.waitForType<FrameMessage>("frame", 10000);
-        }
-        assertEquals(f3.newPage, true, "Plot 3 frame must have newPage");
-
-        // Count untagged frames between plot 2 and plot 3
-        const untaggedBetween2 = postPlot2Frames.filter(
-          (f) => !f.newPage && !f.resize && !f.incremental,
-        );
-        assertEquals(
-          untaggedBetween2.length,
-          0,
-          `No untagged frames should appear between plot 2 and plot 3, ` +
-            `got ${untaggedBetween2.length}`,
-        );
-
-      } finally {
-        r.kill();
+      // Wait for resize frame
+      let gotResize2 = false;
+      const postPlot2Frames: FrameMessage[] = [];
+      for (let i = 0; i < 5; i++) {
         try {
-          await r.process.output();
-        } catch { /* ignore */ }
+          const f = await browser.waitForType<FrameMessage>("frame", 3000);
+          postPlot2Frames.push(f);
+          if (f.resize) {
+            gotResize2 = true;
+            break;
+          }
+          if (f.newPage) break;
+        } catch {
+          break;
+        }
       }
+      assert(gotResize2, "Should receive resize frame after plot 2");
+
+      // Count untagged frames between plot 2 and resize
+      const untaggedBetween2 = postPlot2Frames.filter(
+        (f) => !f.newPage && !f.resize && !f.incremental,
+      );
+      assertEquals(
+        untaggedBetween2.length,
+        0,
+        `No untagged frames should appear between plot 2 and plot 3, ` +
+          `got ${untaggedBetween2.length}`,
+      );
+
+      await arf.eval("plot(7:9)");
+
+      // Wait for plot 3
+      const f3 = await browser.waitForType<FrameMessage>("frame", 10000);
+      assertEquals(f3.newPage, true, "Plot 3 frame must have newPage");
     } finally {
       browser.close();
       await delay(100);
+      await arf.shutdown();
       await server.shutdown();
       server.cleanup();
     }

--- a/tests/newpage_after_resize_test.ts
+++ b/tests/newpage_after_resize_test.ts
@@ -16,6 +16,7 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { testLog } from "./helpers/test_log.ts";
@@ -55,8 +56,8 @@ Deno.test({
 
       // Send a resize with DIFFERENT dimensions to trigger a replay
       browser.sendResize(640, 480);
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       // Collect all frames until we get 3 newPage frames
       const allFrames: FrameMessage[] = [frame1];
@@ -201,8 +202,8 @@ Deno.test({
 
       // Send resize after plot 1
       browser.sendResize(640, 480);
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       // Wait for resize frame
       let gotResize1 = false;
@@ -241,8 +242,8 @@ Deno.test({
 
       // Send resize after plot 2
       browser.sendResize(700, 500);
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       // Wait for resize frame
       let gotResize2 = false;

--- a/tests/newpage_duplicate_fullstack_test.ts
+++ b/tests/newpage_duplicate_fullstack_test.ts
@@ -14,6 +14,7 @@
 import { assertEquals } from "@std/assert";
 import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
+import { testLog } from "./helpers/test_log.ts";
 import {
   E2EBrowser,
   plotInfoText,
@@ -30,6 +31,7 @@ Deno.test({
   name: "Full-stack: R + Browser — 3 plots must show 3/3 (no duplication)",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const e2e = new E2EBrowser();
     const arf = new ArfSession();

--- a/tests/newpage_duplicate_fullstack_test.ts
+++ b/tests/newpage_duplicate_fullstack_test.ts
@@ -66,6 +66,9 @@ Deno.test({
       // Process any browser resize before next plot
       await delay(100);
       await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await assertPlotInfoStable(page, "1 / 1");
+      info = await plotInfoText(page);
+      console.error(`After resize poll before plot 2: "${info}"`);
 
       // Plot 2
       await arf.eval("plot(4:6)");
@@ -85,6 +88,9 @@ Deno.test({
 
       await delay(100);
       await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await assertPlotInfoStable(page, "2 / 2");
+      info = await plotInfoText(page);
+      console.error(`After resize poll before plot 3: "${info}"`);
 
       // Plot 3
       await arf.eval("plot(7:9)");

--- a/tests/newpage_duplicate_fullstack_test.ts
+++ b/tests/newpage_duplicate_fullstack_test.ts
@@ -22,6 +22,7 @@ import {
 } from "../server/tests/helpers/e2e_browser.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
@@ -64,8 +65,7 @@ Deno.test({
       console.error(`After plot 1 + quiet window: "${info}"`);
 
       // Process any browser resize before next plot
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await pollResize(arf, 40);
       await assertPlotInfoStable(page, "1 / 1");
       info = await plotInfoText(page);
       console.error(`After resize poll before plot 2: "${info}"`);
@@ -86,8 +86,7 @@ Deno.test({
           "plot duplication bug detected",
       );
 
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await pollResize(arf, 40);
       await assertPlotInfoStable(page, "2 / 2");
       info = await plotInfoText(page);
       console.error(`After resize poll before plot 3: "${info}"`);

--- a/tests/newpage_duplicate_fullstack_test.ts
+++ b/tests/newpage_duplicate_fullstack_test.ts
@@ -39,7 +39,7 @@ Deno.test({
       const page = await e2e.newPage(server.httpBaseUrl);
 
       // Wait for browser to be ready
-      await delay(500);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -51,12 +51,12 @@ Deno.test({
       await arf.eval("plot(1:3)");
 
       // Wait for plot 1 to appear
-      let info = await waitForPlotCount(page, 1, 10_000);
+      let info = await waitForPlotCount(page, 1, 8_000);
       console.error(`After plot 1: "${info}"`);
       assertEquals(info, "1 / 1", "After plot 1, should show 1 / 1");
 
       // Wait a moment, then verify no extra plots appeared
-      await delay(1000);
+      await delay(300);
       info = await plotInfoText(page);
       console.error(`After plot 1 + 1s settle: "${info}"`);
       assertEquals(
@@ -74,7 +74,7 @@ Deno.test({
       await arf.eval("plot(4:6)");
 
       // Wait for plot 2
-      info = await waitForPlotCount(page, 2, 15_000);
+      info = await waitForPlotCount(page, 2, 8_000);
       console.error(`After plot 2: "${info}"`);
 
       // Key assertion: after 2 plots, toolbar must show "2 / 2"
@@ -93,7 +93,7 @@ Deno.test({
       await arf.eval("plot(7:9)");
 
       // Wait for plot 3
-      info = await waitForPlotCount(page, 3, 15_000);
+      info = await waitForPlotCount(page, 3, 8_000);
       console.error(`After plot 3: "${info}"`);
 
       assertEquals(

--- a/tests/newpage_duplicate_fullstack_test.ts
+++ b/tests/newpage_duplicate_fullstack_test.ts
@@ -20,10 +20,10 @@ import {
   waitForPlotCount,
 } from "../server/tests/helpers/e2e_browser.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name: "Full-stack: R + Browser — 3 plots must show 3/3 (no duplication)",

--- a/tests/newpage_duplicate_fullstack_test.ts
+++ b/tests/newpage_duplicate_fullstack_test.ts
@@ -12,16 +12,13 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { delay } from "@std/async";
-import { TestServer } from "../server/tests/helpers/server.ts";
 import { testLog } from "./helpers/test_log.ts";
 import {
-  E2EBrowser,
   plotInfoText,
   waitForPlotCount,
 } from "../server/tests/helpers/e2e_browser.ts";
-import { toRSocketAddress } from "./helpers/r_process.ts";
-import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { startArfPageTest } from "./helpers/arf_e2e.ts";
 import { pollResize } from "./helpers/arf_poll.ts";
 import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
 
@@ -33,24 +30,10 @@ Deno.test({
   ignore: skip,
   async fn() {
     testLog("test start");
-    const server = new TestServer({ tcp: true });
-    const e2e = new E2EBrowser();
-    const arf = new ArfSession();
+    const ctx = await startArfPageTest({ browserFirst: true });
+    const { arf, page } = ctx;
 
     try {
-      await server.start();
-      await e2e.launch();
-      const page = await e2e.newPage(server.httpBaseUrl);
-
-      // Wait for browser to be ready
-      await delay(100);
-
-      await arf.start();
-      const socketAddr = toRSocketAddress(server.socketPath);
-      await arf.eval(
-        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
-      );
-
       // Plot 1
       await arf.eval("plot(1:3)");
 
@@ -105,11 +88,7 @@ Deno.test({
           "plot duplication bug detected",
       );
     } finally {
-      await arf.shutdown();
-      await e2e.close();
-      await delay(100);
-      await server.shutdown();
-      server.cleanup();
+      await ctx.close();
     }
   },
 });

--- a/tests/newpage_duplicate_fullstack_test.ts
+++ b/tests/newpage_duplicate_fullstack_test.ts
@@ -14,17 +14,24 @@
 import { assertEquals } from "@std/assert";
 import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
-import { E2EBrowser, plotInfoText, waitForPlotCount } from "../server/tests/helpers/e2e_browser.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import {
+  E2EBrowser,
+  plotInfoText,
+  waitForPlotCount,
+} from "../server/tests/helpers/e2e_browser.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
   name: "Full-stack: R + Browser — 3 plots must show 3/3 (no duplication)",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const e2e = new E2EBrowser();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -34,71 +41,69 @@ Deno.test({
       // Wait for browser to be ready
       await delay(500);
 
-      // R creates 3 plots with long delays between them.
-      // Sys.sleep(3) provides ample margin for the test to read between plots.
-      // The polling loop processes resize messages between plots.
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); ' +
-          'plot(1:3); ' +
-          'Sys.sleep(3); ' +
-          'for (i in 1:20) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }; ' +
-          'plot(4:6); ' +
-          'Sys.sleep(3); ' +
-          'for (i in 1:20) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }; ' +
-          'plot(7:9); ' +
-          'Sys.sleep(1); ' +
-          'for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
       );
 
-      try {
-        // Wait for plot 1 to appear
-        let info = await waitForPlotCount(page, 1, 10_000);
-        console.error(`After plot 1: "${info}"`);
-        assertEquals(info, "1 / 1", "After plot 1, should show 1 / 1");
+      // Plot 1
+      await arf.eval("plot(1:3)");
 
-        // Wait a moment, then verify no extra plots appeared
-        await delay(1000);
-        info = await plotInfoText(page);
-        console.error(`After plot 1 + 1s settle: "${info}"`);
-        assertEquals(
-          info,
-          "1 / 1",
-          `After plot 1 + settle, still 1 / 1, got "${info}" — ` +
-            "possible duplication from resize replay",
-        );
+      // Wait for plot 1 to appear
+      let info = await waitForPlotCount(page, 1, 10_000);
+      console.error(`After plot 1: "${info}"`);
+      assertEquals(info, "1 / 1", "After plot 1, should show 1 / 1");
 
-        // Wait for plot 2
-        info = await waitForPlotCount(page, 2, 15_000);
-        console.error(`After plot 2: "${info}"`);
+      // Wait a moment, then verify no extra plots appeared
+      await delay(1000);
+      info = await plotInfoText(page);
+      console.error(`After plot 1 + 1s settle: "${info}"`);
+      assertEquals(
+        info,
+        "1 / 1",
+        `After plot 1 + settle, still 1 / 1, got "${info}" — ` +
+          "possible duplication from resize replay",
+      );
 
-        // Key assertion: after 2 plots, toolbar must show "2 / 2"
-        // The bug would cause "3 / 3" (previous plot duplicated)
-        assertEquals(
-          info,
-          "2 / 2",
-          `After 2 plots, should show 2 / 2, got "${info}" — ` +
-            "plot duplication bug detected",
-        );
+      // Process any browser resize before next plot
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        // Wait for plot 3
-        info = await waitForPlotCount(page, 3, 15_000);
-        console.error(`After plot 3: "${info}"`);
+      // Plot 2
+      await arf.eval("plot(4:6)");
 
-        assertEquals(
-          info,
-          "3 / 3",
-          `After 3 plots, should show 3 / 3, got "${info}" — ` +
-            "plot duplication bug detected",
-        );
+      // Wait for plot 2
+      info = await waitForPlotCount(page, 2, 15_000);
+      console.error(`After plot 2: "${info}"`);
 
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
-      }
+      // Key assertion: after 2 plots, toolbar must show "2 / 2"
+      // The bug would cause "3 / 3" (previous plot duplicated)
+      assertEquals(
+        info,
+        "2 / 2",
+        `After 2 plots, should show 2 / 2, got "${info}" — ` +
+          "plot duplication bug detected",
+      );
+
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      // Plot 3
+      await arf.eval("plot(7:9)");
+
+      // Wait for plot 3
+      info = await waitForPlotCount(page, 3, 15_000);
+      console.error(`After plot 3: "${info}"`);
+
+      assertEquals(
+        info,
+        "3 / 3",
+        `After 3 plots, should show 3 / 3, got "${info}" — ` +
+          "plot duplication bug detected",
+      );
     } finally {
+      await arf.shutdown();
       await e2e.close();
       await delay(100);
       await server.shutdown();

--- a/tests/newpage_duplicate_fullstack_test.ts
+++ b/tests/newpage_duplicate_fullstack_test.ts
@@ -21,6 +21,7 @@ import {
 } from "../server/tests/helpers/e2e_browser.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
@@ -55,16 +56,10 @@ Deno.test({
       console.error(`After plot 1: "${info}"`);
       assertEquals(info, "1 / 1", "After plot 1, should show 1 / 1");
 
-      // Wait a moment, then verify no extra plots appeared
-      await delay(300);
+      // Observe a quiet window to ensure no delayed duplicate frame appears.
+      await assertPlotInfoStable(page, "1 / 1");
       info = await plotInfoText(page);
-      console.error(`After plot 1 + 1s settle: "${info}"`);
-      assertEquals(
-        info,
-        "1 / 1",
-        `After plot 1 + settle, still 1 / 1, got "${info}" — ` +
-          "possible duplication from resize replay",
-      );
+      console.error(`After plot 1 + quiet window: "${info}"`);
 
       // Process any browser resize before next plot
       await delay(100);

--- a/tests/newpage_duplicate_realr_test.ts
+++ b/tests/newpage_duplicate_realr_test.ts
@@ -17,16 +17,20 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
-  name: "Real R: three sequential plots must produce exactly 3 non-resize frames",
-  ignore: !rAvailable,
+  name:
+    "Real R: three sequential plots must produce exactly 3 non-resize frames",
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -34,115 +38,112 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
-      // Three plots with a polling loop to keep R alive
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); plot(1:3); plot(4:6); plot(7:9); for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+      await arf.eval("plot(1:3); plot(4:6); plot(7:9)");
+
+      // Collect all frames that arrive within a reasonable window.
+      // We expect 3 newPage frames (one per plot) plus possibly
+      // resize replay frames and incremental frames.
+      const allFrames: FrameMessage[] = [];
+      const deadline = Date.now() + 20_000;
+      let plotCount = 0;
+
+      while (Date.now() < deadline && plotCount < 3) {
+        try {
+          const frame = await browser.waitForType<FrameMessage>(
+            "frame",
+            5000,
+          );
+          allFrames.push(frame);
+          if (frame.newPage) {
+            plotCount++;
+          }
+        } catch {
+          // Timeout — no more frames
+          break;
+        }
+      }
+
+      // Wait a bit for any trailing frames
+      await delay(1000);
+
+      // Try to read one more frame (should timeout if no extras)
+      let extraFrame: FrameMessage | null = null;
+      try {
+        extraFrame = await browser.waitForType<FrameMessage>("frame", 1000);
+        if (extraFrame) allFrames.push(extraFrame);
+      } catch {
+        // Expected: no extra frames
+      }
+
+      // Categorize frames
+      const newPageFrames = allFrames.filter((f) => f.newPage === true);
+      const resizeFrames = allFrames.filter((f) => f.resize === true);
+      const incrementalFrames = allFrames.filter(
+        (f) => f.incremental === true,
+      );
+      const untaggedFrames = allFrames.filter(
+        (f) => !f.newPage && !f.resize && !f.incremental,
       );
 
-      try {
-        // Collect all frames that arrive within a reasonable window.
-        // We expect 3 newPage frames (one per plot) plus possibly
-        // resize replay frames and incremental frames.
-        const allFrames: FrameMessage[] = [];
-        const deadline = Date.now() + 20_000;
-        let plotCount = 0;
-
-        while (Date.now() < deadline && plotCount < 3) {
-          try {
-            const frame = await browser.waitForType<FrameMessage>(
-              "frame",
-              5000,
-            );
-            allFrames.push(frame);
-            if (frame.newPage) {
-              plotCount++;
-            }
-          } catch {
-            // Timeout — no more frames
-            break;
-          }
-        }
-
-        // Wait a bit for any trailing frames
-        await delay(1000);
-
-        // Try to read one more frame (should timeout if no extras)
-        let extraFrame: FrameMessage | null = null;
-        try {
-          extraFrame = await browser.waitForType<FrameMessage>("frame", 1000);
-          if (extraFrame) allFrames.push(extraFrame);
-        } catch {
-          // Expected: no extra frames
-        }
-
-        // Categorize frames
-        const newPageFrames = allFrames.filter((f) => f.newPage === true);
-        const resizeFrames = allFrames.filter((f) => f.resize === true);
-        const incrementalFrames = allFrames.filter(
-          (f) => f.incremental === true,
-        );
-        const untaggedFrames = allFrames.filter(
-          (f) => !f.newPage && !f.resize && !f.incremental,
-        );
-
-        // Log frame details for debugging
+      // Log frame details for debugging
+      console.error(
+        `\nFrame summary: total=${allFrames.length}, ` +
+          `newPage=${newPageFrames.length}, resize=${resizeFrames.length}, ` +
+          `incremental=${incrementalFrames.length}, untagged=${untaggedFrames.length}`,
+      );
+      for (let i = 0; i < allFrames.length; i++) {
+        const f = allFrames[i];
         console.error(
-          `\nFrame summary: total=${allFrames.length}, ` +
-            `newPage=${newPageFrames.length}, resize=${resizeFrames.length}, ` +
-            `incremental=${incrementalFrames.length}, untagged=${untaggedFrames.length}`,
+          `  frame[${i}]: newPage=${f.newPage}, resize=${f.resize}, ` +
+            `incremental=${f.incremental}, ops=${f.plot.ops.length}`,
         );
-        for (let i = 0; i < allFrames.length; i++) {
-          const f = allFrames[i];
-          console.error(
-            `  frame[${i}]: newPage=${f.newPage}, resize=${f.resize}, ` +
-              `incremental=${f.incremental}, ops=${f.plot.ops.length}`,
-          );
-        }
+      }
 
-        // 3 plots = 3 newPage frames
-        assertEquals(
-          newPageFrames.length,
-          3,
-          `Expected 3 newPage frames for 3 plots, got ${newPageFrames.length}`,
+      // 3 plots = 3 newPage frames
+      assertEquals(
+        newPageFrames.length,
+        3,
+        `Expected 3 newPage frames for 3 plots, got ${newPageFrames.length}`,
+      );
+
+      // No untagged complete frames (these would cause plot duplication)
+      assertEquals(
+        untaggedFrames.length,
+        0,
+        `Expected 0 untagged complete frames, got ${untaggedFrames.length} — ` +
+          "these cause plot duplication in the browser",
+      );
+
+      // Each newPage frame should have ops
+      for (let i = 0; i < newPageFrames.length; i++) {
+        assert(
+          newPageFrames[i].plot.ops.length > 0,
+          `newPage frame ${i} should have ops`,
         );
-
-        // No untagged complete frames (these would cause plot duplication)
-        assertEquals(
-          untaggedFrames.length,
-          0,
-          `Expected 0 untagged complete frames, got ${untaggedFrames.length} — ` +
-            "these cause plot duplication in the browser",
-        );
-
-        // Each newPage frame should have ops
-        for (let i = 0; i < newPageFrames.length; i++) {
-          assert(
-            newPageFrames[i].plot.ops.length > 0,
-            `newPage frame ${i} should have ops`,
-          );
-        }
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
       }
     } finally {
       browser.close();
       await delay(100);
       await server.shutdown();
       server.cleanup();
+      await arf.shutdown();
     }
   },
 });
 
 Deno.test({
-  name: "Real R: three sequential plots must produce exactly 3 non-resize frames (no poll_resize)",
-  ignore: !rAvailable,
+  name:
+    "Real R: three sequential plots must produce exactly 3 non-resize frames (no poll_resize)",
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -150,82 +151,75 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
-      // Three plots WITHOUT a polling loop — simpler scenario.
-      // R will exit after the plots, but the frames should arrive
-      // before R terminates (R flushes on dev.off/close).
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); plot(1:3); plot(4:6); plot(7:9); Sys.sleep(2)',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+      await arf.eval("plot(1:3); plot(4:6); plot(7:9)");
+
+      const allFrames: FrameMessage[] = [];
+      const deadline = Date.now() + 15_000;
+      let plotCount = 0;
+
+      while (Date.now() < deadline && plotCount < 3) {
+        try {
+          const frame = await browser.waitForType<FrameMessage>(
+            "frame",
+            5000,
+          );
+          allFrames.push(frame);
+          if (frame.newPage) {
+            plotCount++;
+          }
+        } catch {
+          break;
+        }
+      }
+
+      // Wait for any trailing frames
+      await delay(1000);
+      try {
+        const extra = await browser.waitForType<FrameMessage>("frame", 1000);
+        if (extra) allFrames.push(extra);
+      } catch {
+        // Expected
+      }
+
+      const newPageFrames = allFrames.filter((f) => f.newPage === true);
+      const untaggedFrames = allFrames.filter(
+        (f) => !f.newPage && !f.resize && !f.incremental,
       );
 
-      try {
-        const allFrames: FrameMessage[] = [];
-        const deadline = Date.now() + 15_000;
-        let plotCount = 0;
-
-        while (Date.now() < deadline && plotCount < 3) {
-          try {
-            const frame = await browser.waitForType<FrameMessage>(
-              "frame",
-              5000,
-            );
-            allFrames.push(frame);
-            if (frame.newPage) {
-              plotCount++;
-            }
-          } catch {
-            break;
-          }
-        }
-
-        // Wait for any trailing frames
-        await delay(1000);
-        try {
-          const extra = await browser.waitForType<FrameMessage>("frame", 1000);
-          if (extra) allFrames.push(extra);
-        } catch {
-          // Expected
-        }
-
-        const newPageFrames = allFrames.filter((f) => f.newPage === true);
-        const untaggedFrames = allFrames.filter(
-          (f) => !f.newPage && !f.resize && !f.incremental,
-        );
-
+      console.error(
+        `\nFrame summary (no poll): total=${allFrames.length}, ` +
+          `newPage=${newPageFrames.length}, untagged=${untaggedFrames.length}`,
+      );
+      for (let i = 0; i < allFrames.length; i++) {
+        const f = allFrames[i];
         console.error(
-          `\nFrame summary (no poll): total=${allFrames.length}, ` +
-            `newPage=${newPageFrames.length}, untagged=${untaggedFrames.length}`,
+          `  frame[${i}]: newPage=${f.newPage}, resize=${f.resize}, ` +
+            `incremental=${f.incremental}, ops=${f.plot.ops.length}`,
         );
-        for (let i = 0; i < allFrames.length; i++) {
-          const f = allFrames[i];
-          console.error(
-            `  frame[${i}]: newPage=${f.newPage}, resize=${f.resize}, ` +
-              `incremental=${f.incremental}, ops=${f.plot.ops.length}`,
-          );
-        }
-
-        assertEquals(
-          newPageFrames.length,
-          3,
-          `Expected 3 newPage frames, got ${newPageFrames.length}`,
-        );
-
-        assertEquals(
-          untaggedFrames.length,
-          0,
-          `Untagged frames cause duplication: got ${untaggedFrames.length}`,
-        );
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
       }
+
+      assertEquals(
+        newPageFrames.length,
+        3,
+        `Expected 3 newPage frames, got ${newPageFrames.length}`,
+      );
+
+      assertEquals(
+        untaggedFrames.length,
+        0,
+        `Untagged frames cause duplication: got ${untaggedFrames.length}`,
+      );
     } finally {
       browser.close();
       await delay(100);
       await server.shutdown();
       server.cleanup();
+      await arf.shutdown();
     }
   },
 });

--- a/tests/newpage_duplicate_realr_test.ts
+++ b/tests/newpage_duplicate_realr_test.ts
@@ -38,9 +38,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await arf.eval(
@@ -153,9 +150,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await arf.eval(

--- a/tests/newpage_duplicate_realr_test.ts
+++ b/tests/newpage_duplicate_realr_test.ts
@@ -17,11 +17,11 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name:

--- a/tests/newpage_duplicate_realr_test.ts
+++ b/tests/newpage_duplicate_realr_test.ts
@@ -36,7 +36,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -56,7 +56,7 @@ Deno.test({
         try {
           const frame = await browser.waitForType<FrameMessage>(
             "frame",
-            5000,
+            2000,
           );
           allFrames.push(frame);
           if (frame.newPage) {
@@ -69,7 +69,7 @@ Deno.test({
       }
 
       // Wait a bit for any trailing frames
-      await delay(1000);
+      await delay(300);
 
       // Try to read one more frame (should timeout if no extras)
       let extraFrame: FrameMessage | null = null;
@@ -149,7 +149,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -166,7 +166,7 @@ Deno.test({
         try {
           const frame = await browser.waitForType<FrameMessage>(
             "frame",
-            5000,
+            2000,
           );
           allFrames.push(frame);
           if (frame.newPage) {
@@ -178,7 +178,7 @@ Deno.test({
       }
 
       // Wait for any trailing frames
-      await delay(1000);
+      await delay(300);
       try {
         const extra = await browser.waitForType<FrameMessage>("frame", 1000);
         if (extra) allFrames.push(extra);

--- a/tests/newpage_duplicate_realr_test.ts
+++ b/tests/newpage_duplicate_realr_test.ts
@@ -17,6 +17,7 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { testLog } from "./helpers/test_log.ts";
@@ -45,9 +46,8 @@ Deno.test({
       await arf.eval(
         `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
       );
-      await arf.eval(
-        "plot(1:3); plot(4:6); plot(7:9); for (i in 1:120) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }",
-      );
+      await arf.eval("plot(1:3); plot(4:6); plot(7:9)");
+      await pollResize(arf, 120);
 
       // Collect all frames that arrive within a reasonable window.
       // We expect 3 newPage frames (one per plot) plus possibly

--- a/tests/newpage_duplicate_realr_test.ts
+++ b/tests/newpage_duplicate_realr_test.ts
@@ -19,6 +19,7 @@ import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
@@ -28,6 +29,7 @@ Deno.test({
     "Real R: three sequential plots must produce exactly 3 non-resize frames",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -143,6 +145,7 @@ Deno.test({
     "Real R: three sequential plots must produce exactly 3 non-resize frames (no poll_resize)",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/newpage_duplicate_realr_test.ts
+++ b/tests/newpage_duplicate_realr_test.ts
@@ -43,7 +43,9 @@ Deno.test({
       await arf.eval(
         `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
       );
-      await arf.eval("plot(1:3); plot(4:6); plot(7:9)");
+      await arf.eval(
+        "plot(1:3); plot(4:6); plot(7:9); for (i in 1:120) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }",
+      );
 
       // Collect all frames that arrive within a reasonable window.
       // We expect 3 newPage frames (one per plot) plus possibly

--- a/tests/newpage_interactive_r_test.ts
+++ b/tests/newpage_interactive_r_test.ts
@@ -61,21 +61,21 @@ Deno.test({
         await send(`options(jgd.socket = "${socketAddr}")`);
         await send("library(jgd)");
         await send("jgd(width=8, height=6, dpi=96)");
-        await delay(1000);
+        await delay(300);
 
         // NOW open browser — R is connected
         await e2e.launch();
         const page = await e2e.newPage(server.httpBaseUrl);
-        await delay(1000);
+        await delay(300);
 
         // Plot 1 — typed interactively (R event loop processes events between commands)
         await send("plot(1:3)");
 
-        let info = await waitForPlotCount(page, 1, 10_000);
+        let info = await waitForPlotCount(page, 1, 8_000);
         console.error(`After plot 1: "${info}"`);
 
         // Settle — check for ghost entries from resize replay
-        await delay(2000);
+        await delay(500);
         info = await plotInfoText(page);
         console.error(`After plot 1 + settle: "${info}"`);
         assertEquals(
@@ -88,7 +88,7 @@ Deno.test({
         // Plot 2 — typed interactively
         await send("plot(4:6)");
 
-        info = await waitForPlotCount(page, 2, 10_000);
+        info = await waitForPlotCount(page, 2, 8_000);
         console.error(`After plot 2: "${info}"`);
         assertEquals(
           info,
@@ -100,7 +100,7 @@ Deno.test({
         // Plot 3
         await send("plot(7:9)");
 
-        info = await waitForPlotCount(page, 3, 10_000);
+        info = await waitForPlotCount(page, 3, 8_000);
         console.error(`After plot 3: "${info}"`);
         assertEquals(
           info,

--- a/tests/newpage_interactive_r_test.ts
+++ b/tests/newpage_interactive_r_test.ts
@@ -9,7 +9,11 @@
 import { assertEquals } from "@std/assert";
 import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
-import { E2EBrowser, plotInfoText, waitForPlotCount } from "../server/tests/helpers/e2e_browser.ts";
+import {
+  E2EBrowser,
+  plotInfoText,
+  waitForPlotCount,
+} from "../server/tests/helpers/e2e_browser.ts";
 import { checkRAvailable, toRSocketAddress } from "./helpers/r_process.ts";
 
 const rAvailable = await checkRAvailable();
@@ -38,13 +42,15 @@ Deno.test({
 
       // Drain stdout/stderr in background
       proc.stdout.pipeTo(new WritableStream({ write() {} })).catch(() => {});
-      proc.stderr.pipeTo(new WritableStream({
-        write(chunk) {
-          if (Deno.env.get("JGD_TEST_VERBOSE")) {
-            Deno.stderr.writeSync(chunk);
-          }
-        },
-      })).catch(() => {});
+      proc.stderr.pipeTo(
+        new WritableStream({
+          write(chunk) {
+            if (Deno.env.get("JGD_TEST_VERBOSE")) {
+              Deno.stderr.writeSync(chunk);
+            }
+          },
+        }),
+      ).catch(() => {});
 
       const send = async (code: string) => {
         await writer.write(encoder.encode(code + "\n"));
@@ -102,12 +108,19 @@ Deno.test({
           `After 3 plots, should show 3 / 3, got "${info}" — ` +
             "plot duplication bug detected",
         );
-
       } finally {
-        try { writer.releaseLock(); } catch { /* ignore */ }
-        try { await proc.stdin.close(); } catch { /* ignore */ }
-        try { proc.kill("SIGKILL"); } catch { /* ignore */ }
-        try { await proc.output(); } catch { /* ignore */ }
+        try {
+          writer.releaseLock();
+        } catch { /* ignore */ }
+        try {
+          await proc.stdin.close();
+        } catch { /* ignore */ }
+        try {
+          proc.kill("SIGKILL");
+        } catch { /* ignore */ }
+        try {
+          await proc.output();
+        } catch { /* ignore */ }
       }
     } finally {
       await e2e.close();

--- a/tests/newpage_interactive_r_test.ts
+++ b/tests/newpage_interactive_r_test.ts
@@ -14,6 +14,7 @@ import {
   plotInfoText,
   waitForPlotCount,
 } from "../server/tests/helpers/e2e_browser.ts";
+import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
 import { checkRAvailable, toRSocketAddress } from "./helpers/r_process.ts";
 
 const rAvailable = await checkRAvailable();
@@ -74,16 +75,10 @@ Deno.test({
         let info = await waitForPlotCount(page, 1, 8_000);
         console.error(`After plot 1: "${info}"`);
 
-        // Settle — check for ghost entries from resize replay
-        await delay(500);
+        // Observe quiet window to catch delayed ghost entries.
+        await assertPlotInfoStable(page, "1 / 1");
         info = await plotInfoText(page);
-        console.error(`After plot 1 + settle: "${info}"`);
-        assertEquals(
-          info,
-          "1 / 1",
-          `After plot 1 + settle, should be 1 / 1, got "${info}" — ` +
-            "resize replay created ghost entry",
-        );
+        console.error(`After plot 1 + quiet window: "${info}"`);
 
         // Plot 2 — typed interactively
         await send("plot(4:6)");

--- a/tests/newpage_interactive_r_test.ts
+++ b/tests/newpage_interactive_r_test.ts
@@ -63,8 +63,10 @@ Deno.test({
       const encoder = new TextEncoder();
 
       // Drain stdout/stderr in background
-      proc.stdout.pipeTo(new WritableStream({ write() {} })).catch(() => {});
-      proc.stderr.pipeTo(
+      const stdoutDrained = proc.stdout.pipeTo(
+        new WritableStream({ write() {} }),
+      ).catch(() => {});
+      const stderrDrained = proc.stderr.pipeTo(
         new WritableStream({
           write(chunk) {
             if (Deno.env.get("JGD_TEST_VERBOSE")) {
@@ -136,8 +138,9 @@ Deno.test({
           proc.kill("SIGKILL");
         } catch { /* ignore */ }
         try {
-          await proc.output();
+          await proc.status;
         } catch { /* ignore */ }
+        await Promise.allSettled([stdoutDrained, stderrDrained]);
       }
     } finally {
       await e2e.close();

--- a/tests/newpage_interactive_r_test.ts
+++ b/tests/newpage_interactive_r_test.ts
@@ -9,6 +9,7 @@
 import { assertEquals } from "@std/assert";
 import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
+import { testLog } from "./helpers/test_log.ts";
 import {
   E2EBrowser,
   plotInfoText,
@@ -23,6 +24,7 @@ Deno.test({
   name: "Interactive R: plots via stdin must not duplicate",
   ignore: !rAvailable,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const e2e = new E2EBrowser();
 

--- a/tests/newpage_interactive_r_test.ts
+++ b/tests/newpage_interactive_r_test.ts
@@ -15,6 +15,7 @@ import {
   plotInfoText,
   waitForPlotCount,
 } from "../server/tests/helpers/e2e_browser.ts";
+import { waitForWsConnected } from "./helpers/page_ready.ts";
 import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
 import { checkRAvailable, toRSocketAddress } from "./helpers/r_process.ts";
 
@@ -91,7 +92,9 @@ Deno.test({
         // NOW open browser — R is connected
         await e2e.launch();
         const page = await e2e.newPage(server.httpBaseUrl);
-        await delay(300);
+        // Deterministic barrier: wait until the page's WebSocket onopen
+        // has actually fired so the first plot frame is not lost on slow CI.
+        await waitForWsConnected(page);
 
         // Plot 1 — typed interactively (R event loop processes events between commands)
         await send("plot(1:3)");

--- a/tests/newpage_interactive_r_test.ts
+++ b/tests/newpage_interactive_r_test.ts
@@ -20,6 +20,21 @@ import { checkRAvailable, toRSocketAddress } from "./helpers/r_process.ts";
 
 const rAvailable = await checkRAvailable();
 
+async function waitForFile(path: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    try {
+      await Deno.stat(path);
+      return;
+    } catch {
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for ${path}`);
+      }
+      await delay(50);
+    }
+  }
+}
+
 Deno.test({
   name: "Interactive R: plots via stdin must not duplicate",
   ignore: !rAvailable,
@@ -27,6 +42,10 @@ Deno.test({
     testLog("test start");
     const server = new TestServer({ tcp: true });
     const e2e = new E2EBrowser();
+    const readyFile = await Deno.makeTempFile({
+      prefix: "jgd-interactive-ready-",
+    });
+    await Deno.remove(readyFile);
 
     try {
       await server.start();
@@ -64,7 +83,8 @@ Deno.test({
         await send(`options(jgd.socket = "${socketAddr}")`);
         await send("library(jgd)");
         await send("jgd(width=8, height=6, dpi=96)");
-        await delay(300);
+        await send(`cat("ready", file = ${JSON.stringify(readyFile)})`);
+        await waitForFile(readyFile);
 
         // NOW open browser — R is connected
         await e2e.launch();
@@ -124,6 +144,9 @@ Deno.test({
       await delay(100);
       await server.shutdown();
       server.cleanup();
+      try {
+        await Deno.remove(readyFile);
+      } catch { /* already removed */ }
     }
   },
 });

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -48,7 +48,7 @@ Deno.test({
       );
 
       // Wait for R to connect to the server
-      await delay(500);
+      await delay(100);
 
       // NOW open browser — R is already connected.
       // ResizeObserver will fire → resize reaches R's socket.
@@ -56,17 +56,17 @@ Deno.test({
       const page = await e2e.newPage(server.httpBaseUrl);
 
       // Settle: let browser connect and send initial resize
-      await delay(1000);
+      await delay(300);
 
       // Plot 1
       await arf.eval("plot(1:3)");
 
       // Wait for plot 1
-      let info = await waitForPlotCount(page, 1, 15_000);
+      let info = await waitForPlotCount(page, 1, 8_000);
       console.error(`After plot 1: "${info}"`);
 
       // Settle: verify no ghost entries from resize processing
-      await delay(1500);
+      await delay(400);
       info = await plotInfoText(page);
       console.error(`After plot 1 + settle: "${info}"`);
       assertEquals(
@@ -84,7 +84,7 @@ Deno.test({
       await arf.eval("plot(4:6)");
 
       // Wait for plot 2
-      info = await waitForPlotCount(page, 2, 15_000);
+      info = await waitForPlotCount(page, 2, 8_000);
       console.error(`After plot 2: "${info}"`);
       assertEquals(
         info,
@@ -101,7 +101,7 @@ Deno.test({
       await arf.eval("plot(7:9)");
 
       // Wait for plot 3
-      info = await waitForPlotCount(page, 3, 15_000);
+      info = await waitForPlotCount(page, 3, 8_000);
       console.error(`After plot 3: "${info}"`);
       assertEquals(
         info,

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -23,10 +23,10 @@ import {
   waitForPlotCount,
 } from "../server/tests/helpers/e2e_browser.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name: "Full-stack: resize arrives during R drawing — must not duplicate",

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -24,6 +24,7 @@ import {
 } from "../server/tests/helpers/e2e_browser.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
@@ -65,16 +66,10 @@ Deno.test({
       let info = await waitForPlotCount(page, 1, 8_000);
       console.error(`After plot 1: "${info}"`);
 
-      // Settle: verify no ghost entries from resize processing
-      await delay(400);
+      // Observe quiet window to catch delayed ghost entries.
+      await assertPlotInfoStable(page, "1 / 1");
       info = await plotInfoText(page);
-      console.error(`After plot 1 + settle: "${info}"`);
-      assertEquals(
-        info,
-        "1 / 1",
-        `After plot 1 + settle, should be 1 / 1, got "${info}" — ` +
-          "resize replay created ghost entry",
-      );
+      console.error(`After plot 1 + quiet window: "${info}"`);
 
       // Process any pending resize
       await delay(100);

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -17,6 +17,7 @@
 import { assertEquals } from "@std/assert";
 import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
+import { testLog } from "./helpers/test_log.ts";
 import {
   E2EBrowser,
   plotInfoText,
@@ -33,6 +34,7 @@ Deno.test({
   name: "Full-stack: resize arrives during R drawing — must not duplicate",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const e2e = new E2EBrowser();
     const arf = new ArfSession();

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -15,16 +15,13 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { delay } from "@std/async";
-import { TestServer } from "../server/tests/helpers/server.ts";
 import { testLog } from "./helpers/test_log.ts";
 import {
-  E2EBrowser,
   plotInfoText,
   waitForPlotCount,
 } from "../server/tests/helpers/e2e_browser.ts";
-import { toRSocketAddress } from "./helpers/r_process.ts";
-import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { startArfPageTest } from "./helpers/arf_e2e.ts";
 import { pollResize } from "./helpers/arf_poll.ts";
 import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
 
@@ -36,32 +33,10 @@ Deno.test({
   ignore: skip,
   async fn() {
     testLog("test start");
-    const server = new TestServer({ tcp: true });
-    const e2e = new E2EBrowser();
-    const arf = new ArfSession();
+    const ctx = await startArfPageTest({ browserFirst: false });
+    const { arf, page } = ctx;
 
     try {
-      await server.start();
-
-      // Start R FIRST — before browser — so R is connected when
-      // the browser's ResizeObserver fires.
-      await arf.start();
-      const socketAddr = toRSocketAddress(server.socketPath);
-      await arf.eval(
-        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
-      );
-
-      // Wait for R to connect to the server
-      await delay(100);
-
-      // NOW open browser — R is already connected.
-      // ResizeObserver will fire → resize reaches R's socket.
-      await e2e.launch();
-      const page = await e2e.newPage(server.httpBaseUrl);
-
-      // Settle: let browser connect and send initial resize
-      await delay(300);
-
       // Plot 1
       await arf.eval("plot(1:3)");
 
@@ -112,11 +87,7 @@ Deno.test({
           "plot duplication bug detected",
       );
     } finally {
-      await arf.shutdown();
-      await e2e.close();
-      await delay(100);
-      await server.shutdown();
-      server.cleanup();
+      await ctx.close();
     }
   },
 });

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -76,6 +76,9 @@ Deno.test({
       // Process any pending resize
       await delay(100);
       await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await assertPlotInfoStable(page, "1 / 1");
+      info = await plotInfoText(page);
+      console.error(`After resize poll before plot 2: "${info}"`);
 
       // Plot 2
       await arf.eval("plot(4:6)");
@@ -93,6 +96,9 @@ Deno.test({
       // Poll resize
       await delay(100);
       await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await assertPlotInfoStable(page, "2 / 2");
+      info = await plotInfoText(page);
+      console.error(`After resize poll before plot 3: "${info}"`);
 
       // Plot 3
       await arf.eval("plot(7:9)");

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -25,6 +25,7 @@ import {
 } from "../server/tests/helpers/e2e_browser.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
@@ -74,8 +75,7 @@ Deno.test({
       console.error(`After plot 1 + quiet window: "${info}"`);
 
       // Process any pending resize
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await pollResize(arf, 40);
       await assertPlotInfoStable(page, "1 / 1");
       info = await plotInfoText(page);
       console.error(`After resize poll before plot 2: "${info}"`);
@@ -94,8 +94,7 @@ Deno.test({
       );
 
       // Poll resize
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await pollResize(arf, 40);
       await assertPlotInfoStable(page, "2 / 2");
       info = await plotInfoText(page);
       console.error(`After resize poll before plot 3: "${info}"`);

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -17,91 +17,100 @@
 import { assertEquals } from "@std/assert";
 import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
-import { E2EBrowser, plotInfoText, waitForPlotCount } from "../server/tests/helpers/e2e_browser.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import {
+  E2EBrowser,
+  plotInfoText,
+  waitForPlotCount,
+} from "../server/tests/helpers/e2e_browser.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
   name: "Full-stack: resize arrives during R drawing — must not duplicate",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const e2e = new E2EBrowser();
+    const arf = new ArfSession();
 
     try {
       await server.start();
 
       // Start R FIRST — before browser — so R is connected when
       // the browser's ResizeObserver fires.
-      // R sleeps long enough for the browser to launch and connect
-      // (Windows CI can take 5-10s to launch headless Chrome).
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); ' +
-          'Sys.sleep(8); ' +
-          'plot(1:3); ' +
-          'Sys.sleep(3); ' +
-          'for (i in 1:20) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }; ' +
-          'plot(4:6); ' +
-          'Sys.sleep(3); ' +
-          'for (i in 1:20) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }; ' +
-          'plot(7:9); ' +
-          'Sys.sleep(1); ' +
-          'for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
       );
 
-      try {
-        // Wait for R to load library and connect to the server
-        await delay(2000);
+      // Wait for R to connect to the server
+      await delay(500);
 
-        // NOW open browser — R is already connected.
-        // ResizeObserver will fire → resize reaches R's socket.
-        await e2e.launch();
-        const page = await e2e.newPage(server.httpBaseUrl);
+      // NOW open browser — R is already connected.
+      // ResizeObserver will fire → resize reaches R's socket.
+      await e2e.launch();
+      const page = await e2e.newPage(server.httpBaseUrl);
 
-        // Wait for plot 1
-        let info = await waitForPlotCount(page, 1, 15_000);
-        console.error(`After plot 1: "${info}"`);
+      // Settle: let browser connect and send initial resize
+      await delay(1000);
 
-        // Settle: verify no ghost entries from resize processing
-        await delay(1500);
-        info = await plotInfoText(page);
-        console.error(`After plot 1 + settle: "${info}"`);
-        assertEquals(
-          info,
-          "1 / 1",
-          `After plot 1 + settle, should be 1 / 1, got "${info}" — ` +
-            "resize replay created ghost entry",
-        );
+      // Plot 1
+      await arf.eval("plot(1:3)");
 
-        // Wait for plot 2
-        info = await waitForPlotCount(page, 2, 15_000);
-        console.error(`After plot 2: "${info}"`);
-        assertEquals(
-          info,
-          "2 / 2",
-          `After 2 plots, should show 2 / 2, got "${info}" — ` +
-            "plot duplication bug detected",
-        );
+      // Wait for plot 1
+      let info = await waitForPlotCount(page, 1, 15_000);
+      console.error(`After plot 1: "${info}"`);
 
-        // Wait for plot 3
-        info = await waitForPlotCount(page, 3, 15_000);
-        console.error(`After plot 3: "${info}"`);
-        assertEquals(
-          info,
-          "3 / 3",
-          `After 3 plots, should show 3 / 3, got "${info}" — ` +
-            "plot duplication bug detected",
-        );
+      // Settle: verify no ghost entries from resize processing
+      await delay(1500);
+      info = await plotInfoText(page);
+      console.error(`After plot 1 + settle: "${info}"`);
+      assertEquals(
+        info,
+        "1 / 1",
+        `After plot 1 + settle, should be 1 / 1, got "${info}" — ` +
+          "resize replay created ghost entry",
+      );
 
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
-      }
+      // Process any pending resize
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      // Plot 2
+      await arf.eval("plot(4:6)");
+
+      // Wait for plot 2
+      info = await waitForPlotCount(page, 2, 15_000);
+      console.error(`After plot 2: "${info}"`);
+      assertEquals(
+        info,
+        "2 / 2",
+        `After 2 plots, should show 2 / 2, got "${info}" — ` +
+          "plot duplication bug detected",
+      );
+
+      // Poll resize
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      // Plot 3
+      await arf.eval("plot(7:9)");
+
+      // Wait for plot 3
+      info = await waitForPlotCount(page, 3, 15_000);
+      console.error(`After plot 3: "${info}"`);
+      assertEquals(
+        info,
+        "3 / 3",
+        `After 3 plots, should show 3 / 3, got "${info}" — ` +
+          "plot duplication bug detected",
+      );
     } finally {
+      await arf.shutdown();
       await e2e.close();
       await delay(100);
       await server.shutdown();

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -32,12 +32,8 @@ const skip = !arfTestAvailable;
 
 async function pollUntilResizeReplay(
   arf: ArfSession,
-  observer: BrowserClient,
+  replayFramePromise: Promise<FrameMessage>,
 ): Promise<void> {
-  const replayFramePromise = observer.waitForMessage<FrameMessage>(
-    (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-    8_000,
-  );
   let replayDone = false;
   replayFramePromise.then(() => (replayDone = true)).catch(
     () => (replayDone = true),
@@ -61,6 +57,13 @@ Deno.test({
 
     try {
       await observer.connect(server.wsUrl);
+      const replayFramePromise = observer.waitForMessage<FrameMessage>(
+        (msg) =>
+          msg.type === "frame" &&
+          (msg as FrameMessage).resize === true &&
+          (msg as FrameMessage).resizeReplay === true,
+        8_000,
+      );
 
       // Force a browser-originated resize while R is connected, then start
       // drawing immediately. The ResizeObserver debounce can let this arrive
@@ -85,7 +88,7 @@ Deno.test({
       console.error(`After plot 1 + quiet window: "${info}"`);
 
       // Process the browser-originated resize and require an observable replay.
-      await pollUntilResizeReplay(arf, observer);
+      await pollUntilResizeReplay(arf, replayFramePromise);
       await assertPlotInfoStable(page, "1 / 1");
       info = await plotInfoText(page);
       console.error(`After resize poll before plot 2: "${info}"`);

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -20,7 +20,9 @@ import {
   plotInfoText,
   waitForPlotCount,
 } from "../server/tests/helpers/e2e_browser.ts";
-import { checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { BrowserClient } from "../server/tests/helpers/browser_client.ts";
+import type { FrameMessage } from "../server/tests/helpers/types.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { startArfPageTest } from "./helpers/arf_e2e.ts";
 import { pollResize } from "./helpers/arf_poll.ts";
 import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
@@ -28,15 +30,48 @@ import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
 
+async function pollUntilResizeReplay(
+  arf: ArfSession,
+  observer: BrowserClient,
+): Promise<void> {
+  const replayFramePromise = observer.waitForMessage<FrameMessage>(
+    (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+    8_000,
+  );
+  let replayDone = false;
+  replayFramePromise.then(() => (replayDone = true)).catch(
+    () => (replayDone = true),
+  );
+
+  const deadline = Date.now() + 7_000;
+  while (!replayDone && Date.now() < deadline) {
+    await pollResize(arf, 40);
+  }
+  await replayFramePromise;
+}
+
 Deno.test({
   name: "Full-stack: resize arrives during R drawing — must not duplicate",
   ignore: skip,
   async fn() {
     testLog("test start");
     const ctx = await startArfPageTest({ browserFirst: false });
-    const { arf, page } = ctx;
+    const { arf, page, server } = ctx;
+    const observer = new BrowserClient();
 
     try {
+      await observer.connect(server.wsUrl);
+
+      // Force a browser-originated resize while R is connected, then start
+      // drawing immediately. The ResizeObserver debounce can let this arrive
+      // while plot 1 is in progress; the replay assertion below proves R saw
+      // and processed it.
+      await page.evaluate(`(function() {
+        var c = document.getElementById('canvas-container');
+        c.style.width = '620px';
+        c.style.height = '420px';
+      })()`);
+
       // Plot 1
       await arf.eval("plot(1:3)");
 
@@ -49,8 +84,8 @@ Deno.test({
       info = await plotInfoText(page);
       console.error(`After plot 1 + quiet window: "${info}"`);
 
-      // Process any pending resize
-      await pollResize(arf, 40);
+      // Process the browser-originated resize and require an observable replay.
+      await pollUntilResizeReplay(arf, observer);
       await assertPlotInfoStable(page, "1 / 1");
       info = await plotInfoText(page);
       console.error(`After resize poll before plot 2: "${info}"`);
@@ -68,7 +103,8 @@ Deno.test({
           "plot duplication bug detected",
       );
 
-      // Poll resize
+      // Poll any later resize without requiring one: the initial resize replay
+      // above is the coverage target for this regression.
       await pollResize(arf, 40);
       await assertPlotInfoStable(page, "2 / 2");
       info = await plotInfoText(page);
@@ -87,6 +123,7 @@ Deno.test({
           "plot duplication bug detected",
       );
     } finally {
+      observer.close();
       await ctx.close();
     }
   },

--- a/tests/newpage_resize_during_draw_test.ts
+++ b/tests/newpage_resize_during_draw_test.ts
@@ -29,6 +29,7 @@ import { assertPlotInfoStable } from "./helpers/plot_settle.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
+const RESIZE_REPLAY_TIMEOUT_MS = 20_000;
 
 async function pollUntilResizeReplay(
   arf: ArfSession,
@@ -62,7 +63,7 @@ Deno.test({
           msg.type === "frame" &&
           (msg as FrameMessage).resize === true &&
           (msg as FrameMessage).resizeReplay === true,
-        8_000,
+        RESIZE_REPLAY_TIMEOUT_MS,
       );
 
       // Force a browser-originated resize while R is connected, then start

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -60,7 +60,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -48,9 +48,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await arf.eval(

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -24,10 +24,10 @@ import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 const FRAME_WAIT_MS = 1000;
 const NEWPAGE_DEADLINE_MS = 6000;
 

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -84,7 +84,8 @@ Deno.test({
           frames.push(msg);
           if (msg.newPage) newPageCount++;
         } catch {
-          break;
+          // Keep polling until the overall deadline; ggplot2/grid frame
+          // delivery can have transient gaps.
         }
       }
 

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -23,6 +23,7 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { checkGgplot2Available } from "./helpers/r_packages.ts";
@@ -34,23 +35,6 @@ const skip = !ggplot2Available;
 
 const FRAME_WAIT_MS = 1000;
 const NEWPAGE_DEADLINE_MS = 6000;
-
-async function evalOk(
-  arf: ArfSession,
-  code: string,
-  timeoutMs?: number,
-): Promise<void> {
-  const result = await arf.eval(code, timeoutMs);
-  assertEquals(result.error, null, `R eval failed: ${result.error}`);
-}
-
-async function pollR(arf: ArfSession, iterations = 120): Promise<void> {
-  await evalOk(
-    arf,
-    `for (i in 1:${iterations}) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }`,
-    60_000,
-  );
-}
 
 Deno.test({
   name: "E2E: abline survives plotIndex resize when ggplot2 is the next plot",
@@ -69,25 +53,22 @@ Deno.test({
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
-      await evalOk(
-        arf,
+      await arf.eval(
         `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
       );
 
       // Plot 1: plot(cars) + abline (base graphics with line annotation)
       // Plot 2: ggplot2 (grid-based — triggers the bug path)
-      await evalOk(
-        arf,
+      await arf.eval(
         'library(ggplot2); plot(cars); abline(lm(dist ~ speed, data = cars), col = "red", lwd = 2)',
       );
-      await pollR(arf, 80);
+      await pollResize(arf, 80);
 
       // Plot 3: another base plot (pushes plot 1 to snapshot history)
-      await evalOk(
-        arf,
+      await arf.eval(
         "print(ggplot(mpg, aes(displ, hwy)) + geom_point()); plot(1:5)",
       );
-      await pollR(arf, 120);
+      await pollResize(arf, 120);
 
       // Collect frames until we have at least 3 newPage frames
       const frames: FrameMessage[] = [];
@@ -126,7 +107,7 @@ Deno.test({
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
 
       await delay(100);
-      await pollR(arf, 40);
+      await pollResize(arf, 40);
 
       const resized = await browser.waitForMessage<FrameMessage>(
         (msg) =>

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -25,6 +25,7 @@ import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const ggplot2Available = arfTestAvailable && await checkGgplot2Available();
@@ -68,6 +69,7 @@ Deno.test({
   name: "E2E: abline survives plotIndex resize when ggplot2 is the next plot",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -107,7 +107,9 @@ Deno.test({
       // Use plotIndex 0 to resize the base plot with abline.
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
 
-      await delay(100);
+      // Ping ordering probe: the WebSocket is FIFO, so awaiting the pong
+      // guarantees the server has already enqueued the resize before R polls.
+      await browser.sendPing(3000);
       await pollResize(arf, 40);
 
       const resized = await browser.waitForMessage<FrameMessage>(

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -23,16 +23,38 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
+const FRAME_WAIT_MS = 1000;
+const NEWPAGE_DEADLINE_MS = 6000;
+
+async function evalOk(
+  arf: ArfSession,
+  code: string,
+  timeoutMs?: number,
+): Promise<void> {
+  const result = await arf.eval(code, timeoutMs);
+  assertEquals(result.error, null, `R eval failed: ${result.error}`);
+}
+
+async function pollR(arf: ArfSession, iterations = 120): Promise<void> {
+  await evalOk(
+    arf,
+    `for (i in 1:${iterations}) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }`,
+    60_000,
+  );
+}
 
 Deno.test({
   name: "E2E: abline survives plotIndex resize when ggplot2 is the next plot",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -40,96 +62,110 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await evalOk(
+        arf,
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+
       // Plot 1: plot(cars) + abline (base graphics with line annotation)
       // Plot 2: ggplot2 (grid-based — triggers the bug path)
+      await evalOk(
+        arf,
+        'library(ggplot2); plot(cars); abline(lm(dist ~ speed, data = cars), col = "red", lwd = 2)',
+      );
+      await pollR(arf, 80);
+
       // Plot 3: another base plot (pushes plot 1 to snapshot history)
-      // Then poll for resize.
-      const rCode = [
-        "library(ggplot2)",
-        "jgd(width=8, height=6, dpi=96)",
-        "plot(cars)",
-        "abline(lm(dist ~ speed, data = cars), col = 'red', lwd = 2)",
-        "ggplot(mpg, aes(displ, hwy)) + geom_point()",
-        "plot(1:5)",
-        "for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }",
-      ].join("; ");
+      await evalOk(
+        arf,
+        "print(ggplot(mpg, aes(displ, hwy)) + geom_point()); plot(1:5)",
+      );
+      await pollR(arf, 120);
 
-      const r = startR(rCode, server.socketPath);
+      // Collect frames until we have at least 3 newPage frames
+      const frames: FrameMessage[] = [];
+      let newPageCount = 0;
+      const deadline = Date.now() + NEWPAGE_DEADLINE_MS;
 
-      try {
-        // Collect frames until we have at least 3 newPage frames
-        const frames: FrameMessage[] = [];
-        let newPageCount = 0;
-        const deadline = Date.now() + 30000;
-
-        while (newPageCount < 3 && Date.now() < deadline) {
-          const msg = await browser.waitForType<FrameMessage>("frame", 15000);
+      while (newPageCount < 3 && Date.now() < deadline) {
+        try {
+          const msg = await browser.waitForType<FrameMessage>(
+            "frame",
+            FRAME_WAIT_MS,
+          );
           frames.push(msg);
           if (msg.newPage) newPageCount++;
+        } catch {
+          break;
         }
+      }
 
-        assert(
-          newPageCount >= 3,
-          `Expected at least 3 newPage frames, got ${newPageCount}`,
-        );
+      assert(
+        newPageCount >= 3,
+        `Expected at least 3 newPage frames, got ${newPageCount}`,
+      );
 
-        // Find newPage frames: [plot(cars), ggplot2, plot(1:5)]
-        const newPageFrames = frames.filter((f) => f.newPage);
-        const carsFrame = newPageFrames[0]; // plot(cars) is the first newPage
+      // Find newPage frames: [plot(cars), ggplot2, plot(1:5)]
+      const newPageFrames = frames.filter((f) => f.newPage);
+      const carsFrame = newPageFrames[0]; // plot(cars) is the first newPage
 
-        assert(carsFrame, "cars plot frame should exist");
+      assert(carsFrame, "cars plot frame should exist");
 
-        // Get sessionId for plotIndex resize
-        const sessionId = carsFrame.plot.sessionId!;
+      // Get sessionId for plotIndex resize
+      const sessionId = carsFrame.plot.sessionId!;
 
-        // plotIndex 0 = plot(cars)+abline, plotIndex 1 = ggplot2
-        // Use plotIndex 0 to resize the base plot with abline.
-        browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
+      // plotIndex 0 = plot(cars)+abline, plotIndex 1 = ggplot2
+      // Use plotIndex 0 to resize the base plot with abline.
+      browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
 
-        const resized = await browser.waitForMessage<FrameMessage>(
-          (msg) =>
-            msg.type === "frame" && (msg as FrameMessage).resize === true &&
-            (msg as FrameMessage).plotIndex === 0,
-          15000,
-        );
+      await delay(100);
+      await pollR(arf, 40);
 
-        assertEquals(
-          resized.resize,
-          true,
-          "Resized frame should have resize:true",
-        );
-        assertEquals(
-          resized.plotIndex,
-          0,
-          "Resized frame should have plotIndex=0",
-        );
+      const resized = await browser.waitForMessage<FrameMessage>(
+        (msg) =>
+          msg.type === "frame" && (msg as FrameMessage).resize === true &&
+          (msg as FrameMessage).plotIndex === 0,
+        FRAME_WAIT_MS,
+      );
 
-        // The resized frame MUST contain abline's red line.
-        // The snapshot's display list must include the abline annotation,
-        // not just the base plot(cars) scatter and tick marks.
-        const resizedOps = resized.plot.ops as Array<Record<string, unknown>>;
-        const redLineOps = resizedOps.filter((op) => {
-          if (op.op !== "line") return false;
-          const gc = op.gc as Record<string, unknown> | undefined;
-          const col = (gc?.col as string | undefined) ?? "";
-          // Color may be "#ff0000", "rgba(255,0,0,1)", etc.
-          return col.toLowerCase().includes("ff0000") ||
-            col.includes("255,0,0");
-        });
-        assert(
-          redLineOps.length > 0,
-          `Resized plot(cars) must contain red line op from abline(), ` +
-            `got line colors: ${JSON.stringify(
+      assertEquals(
+        resized.resize,
+        true,
+        "Resized frame should have resize:true",
+      );
+      assertEquals(
+        resized.plotIndex,
+        0,
+        "Resized frame should have plotIndex=0",
+      );
+
+      // The resized frame MUST contain abline's red line.
+      // The snapshot's display list must include the abline annotation,
+      // not just the base plot(cars) scatter and tick marks.
+      const resizedOps = resized.plot.ops as Array<Record<string, unknown>>;
+      const redLineOps = resizedOps.filter((op) => {
+        if (op.op !== "line") return false;
+        const gc = op.gc as Record<string, unknown> | undefined;
+        const col = (gc?.col as string | undefined) ?? "";
+        // Color may be "#ff0000", "rgba(255,0,0,1)", etc.
+        return col.toLowerCase().includes("ff0000") ||
+          col.includes("255,0,0");
+      });
+      assert(
+        redLineOps.length > 0,
+        `Resized plot(cars) must contain red line op from abline(), ` +
+          `got line colors: ${
+            JSON.stringify(
               resizedOps
                 .filter((o) => o.op === "line")
                 .map((o) => (o.gc as Record<string, unknown>)?.col),
-            )}`,
-        );
-      } finally {
-        r.kill();
-        try { await r.process.output(); } catch { /* ignore */ }
-      }
+            )
+          }`,
+      );
     } finally {
+      await arf.shutdown();
       await browser.close();
       await delay(100);
       await server.shutdown();

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -27,7 +27,23 @@ import { toRSocketAddress } from "./helpers/r_process.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
-const skip = !arfTestAvailable;
+const ggplot2Available = arfTestAvailable && await checkGgplot2Available();
+const skip = !ggplot2Available;
+
+async function checkGgplot2Available(): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command("Rscript", {
+      args: ["-e", 'library(ggplot2); cat("ok")'],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const output = await cmd.output();
+    const stdout = new TextDecoder().decode(output.stdout);
+    return output.success && stdout.includes("ok");
+  } catch {
+    return false;
+  }
+}
 const FRAME_WAIT_MS = 1000;
 const NEWPAGE_DEADLINE_MS = 6000;
 

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -33,8 +33,13 @@ const arfTestAvailable = await checkArfTestAvailable();
 const ggplot2Available = arfTestAvailable && await checkGgplot2Available();
 const skip = !ggplot2Available;
 
+// Per-iteration step for the frame-collection polling loop below: a short
+// wait so the loop can advance quickly when frames have stopped arriving.
 const FRAME_WAIT_MS = 1000;
 const NEWPAGE_DEADLINE_MS = 6000;
+// Separate timeout for the plotIndex resize replay frame: server→browser
+// delivery can lag noticeably on slow CI even after R has finished polling.
+const RESIZE_REPLAY_MS = 15_000;
 
 Deno.test({
   name: "E2E: abline survives plotIndex resize when ggplot2 is the next plot",
@@ -113,7 +118,7 @@ Deno.test({
         (msg) =>
           msg.type === "frame" && (msg as FrameMessage).resize === true &&
           (msg as FrameMessage).plotIndex === 0,
-        FRAME_WAIT_MS,
+        RESIZE_REPLAY_MS,
       );
 
       assertEquals(

--- a/tests/plotindex_abline_after_ggplot2_test.ts
+++ b/tests/plotindex_abline_after_ggplot2_test.ts
@@ -25,26 +25,13 @@ import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { checkGgplot2Available } from "./helpers/r_packages.ts";
 import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const ggplot2Available = arfTestAvailable && await checkGgplot2Available();
 const skip = !ggplot2Available;
 
-async function checkGgplot2Available(): Promise<boolean> {
-  try {
-    const cmd = new Deno.Command("Rscript", {
-      args: ["-e", 'library(ggplot2); cat("ok")'],
-      stdout: "piped",
-      stderr: "piped",
-    });
-    const output = await cmd.output();
-    const stdout = new TextDecoder().decode(output.stdout);
-    return output.success && stdout.includes("ok");
-  } catch {
-    return false;
-  }
-}
 const FRAME_WAIT_MS = 1000;
 const NEWPAGE_DEADLINE_MS = 6000;
 

--- a/tests/plotindex_e2e_test.ts
+++ b/tests/plotindex_e2e_test.ts
@@ -34,7 +34,7 @@ Deno.test({
     const ctx = await startArfBrowserTest();
 
     try {
-      testLog("server/browser connected and initial resize sent");
+      testLog("server/browser connected and arf session started");
       testLog("plot generation begin");
       const [frame1, frame2] = await createTwoBasePlots(ctx);
       testLog("R device initialized and two plots generated");

--- a/tests/plotindex_e2e_test.ts
+++ b/tests/plotindex_e2e_test.ts
@@ -40,11 +40,16 @@ Deno.test({
       await delay(100);
       testLog("server/browser connected and initial resize sent");
 
-      await arf.start();
+      testLog("arf.start begin");
+      await arf.start({ timeoutMs: 15_000 });
+      testLog("arf.start done");
       const socketAddr = toRSocketAddress(server.socketPath);
+      testLog("jgd device setup begin");
       await arf.eval(
         `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+        15_000,
       );
+      testLog("plot generation begin");
       await arf.eval("plot(1:3); plot(4:6)");
       testLog("R device initialized and two plots generated");
 
@@ -62,7 +67,7 @@ Deno.test({
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
       await delay(100); // allow WS message to propagate to server
       testLog("sent resize with plotIndex=0; calling poll_resize");
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)", 10_000);
       testLog("poll_resize returned for plotIndex=0");
 
       const resized0 = await browser.waitForMessage<FrameMessage>(
@@ -98,7 +103,7 @@ Deno.test({
       browser.sendResizeWithPlotIndex(700, 500, 1, sessionId);
       await delay(100); // allow WS message to propagate to server
       testLog("sent resize with plotIndex=1; calling poll_resize");
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)", 10_000);
       testLog("poll_resize returned for plotIndex=1");
 
       const resized1 = await browser.waitForMessage<FrameMessage>(
@@ -137,7 +142,7 @@ Deno.test({
       browser.sendResize(750, 550);
       await delay(100); // allow WS message to propagate to server
       testLog("sent normal resize; calling poll_resize");
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)", 10_000);
       testLog("poll_resize returned for normal resize");
 
       const normalResize = await browser.waitForMessage<FrameMessage>(
@@ -175,6 +180,7 @@ Deno.test({
       browser.close();
       await delay(100);
       await server.shutdown();
+      testLog("plotindex_e2e_test server shutdown done");
       server.cleanup();
       await arf.shutdown();
       testLog("plotindex_e2e_test cleanup done");

--- a/tests/plotindex_e2e_test.ts
+++ b/tests/plotindex_e2e_test.ts
@@ -15,6 +15,7 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
@@ -65,9 +66,9 @@ Deno.test({
       // --- Test 1: plotIndex=0 resize re-renders the first plot ---
       const sessionId = frame1.plot.sessionId!;
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
-      await delay(100); // allow WS message to propagate to server
+      await browser.sendPing(3000);
       testLog("sent resize with plotIndex=0; calling poll_resize");
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)", 10_000);
+      await pollResize(arf, 40);
       testLog("poll_resize returned for plotIndex=0");
 
       const resized0 = await browser.waitForMessage<FrameMessage>(
@@ -101,9 +102,9 @@ Deno.test({
       // through to a normal resize of the current display list.  The frame
       // should have resize:true but no plotIndex.
       browser.sendResizeWithPlotIndex(700, 500, 1, sessionId);
-      await delay(100); // allow WS message to propagate to server
+      await browser.sendPing(3000);
       testLog("sent resize with plotIndex=1; calling poll_resize");
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)", 10_000);
+      await pollResize(arf, 40);
       testLog("poll_resize returned for plotIndex=1");
 
       const resized1 = await browser.waitForMessage<FrameMessage>(
@@ -140,9 +141,9 @@ Deno.test({
 
       // --- Test 3: normal resize (no plotIndex) still works ---
       browser.sendResize(750, 550);
-      await delay(100); // allow WS message to propagate to server
+      await browser.sendPing(3000);
       testLog("sent normal resize; calling poll_resize");
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)", 10_000);
+      await pollResize(arf, 40);
       testLog("poll_resize returned for normal resize");
 
       const normalResize = await browser.waitForMessage<FrameMessage>(

--- a/tests/plotindex_e2e_test.ts
+++ b/tests/plotindex_e2e_test.ts
@@ -18,6 +18,7 @@ import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
@@ -26,6 +27,8 @@ Deno.test({
   name: "E2E: plotIndex resize re-renders historical plot",
   ignore: skip,
   async fn() {
+    testLog("test start");
+    testLog("plotindex_e2e_test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -35,6 +38,7 @@ Deno.test({
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
       await delay(100);
+      testLog("server/browser connected and initial resize sent");
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -42,24 +46,30 @@ Deno.test({
         `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
       );
       await arf.eval("plot(1:3); plot(4:6)");
+      testLog("R device initialized and two plots generated");
 
       // Wait for both frames
       const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame1.plot.ops.length > 0, "First frame should have ops");
+      testLog("received frame1");
 
       const frame2 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame2.plot.ops.length > 0, "Second frame should have ops");
+      testLog("received frame2");
 
       // --- Test 1: plotIndex=0 resize re-renders the first plot ---
       const sessionId = frame1.plot.sessionId!;
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
       await delay(100); // allow WS message to propagate to server
+      testLog("sent resize with plotIndex=0; calling poll_resize");
       await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      testLog("poll_resize returned for plotIndex=0");
 
       const resized0 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
         6000,
       );
+      testLog("received resized frame for plotIndex=0");
 
       assertEquals(
         resized0.resize,
@@ -87,12 +97,15 @@ Deno.test({
       // should have resize:true but no plotIndex.
       browser.sendResizeWithPlotIndex(700, 500, 1, sessionId);
       await delay(100); // allow WS message to propagate to server
+      testLog("sent resize with plotIndex=1; calling poll_resize");
       await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      testLog("poll_resize returned for plotIndex=1");
 
       const resized1 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
         6000,
       );
+      testLog("received resized frame for plotIndex=1/latest");
 
       assertEquals(
         resized1.resize,
@@ -123,12 +136,15 @@ Deno.test({
       // --- Test 3: normal resize (no plotIndex) still works ---
       browser.sendResize(750, 550);
       await delay(100); // allow WS message to propagate to server
+      testLog("sent normal resize; calling poll_resize");
       await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      testLog("poll_resize returned for normal resize");
 
       const normalResize = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
         6000,
       );
+      testLog("received normal resize frame");
 
       assertEquals(
         normalResize.resize,
@@ -153,12 +169,15 @@ Deno.test({
         JSON.stringify(texts1),
         "Normal resize should re-render the current (latest) plot, matching plotIndex=1",
       );
+      testLog("plotindex_e2e_test assertions complete");
     } finally {
+      testLog("plotindex_e2e_test cleanup start");
       browser.close();
       await delay(100);
       await server.shutdown();
       server.cleanup();
       await arf.shutdown();
+      testLog("plotindex_e2e_test cleanup done");
     }
   },
 });

--- a/tests/plotindex_e2e_test.ts
+++ b/tests/plotindex_e2e_test.ts
@@ -16,11 +16,11 @@ import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name: "E2E: plotIndex resize re-renders historical plot",

--- a/tests/plotindex_e2e_test.ts
+++ b/tests/plotindex_e2e_test.ts
@@ -34,7 +34,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -44,10 +44,10 @@ Deno.test({
       await arf.eval("plot(1:3); plot(4:6)");
 
       // Wait for both frames
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame1.plot.ops.length > 0, "First frame should have ops");
 
-      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame2.plot.ops.length > 0, "Second frame should have ops");
 
       // --- Test 1: plotIndex=0 resize re-renders the first plot ---
@@ -58,7 +58,7 @@ Deno.test({
 
       const resized0 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
 
       assertEquals(
@@ -91,7 +91,7 @@ Deno.test({
 
       const resized1 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
 
       assertEquals(
@@ -127,7 +127,7 @@ Deno.test({
 
       const normalResize = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
 
       assertEquals(

--- a/tests/plotindex_e2e_test.ts
+++ b/tests/plotindex_e2e_test.ts
@@ -11,14 +11,15 @@
  */
 
 import { assert, assertEquals, assertNotEquals } from "@std/assert";
-import { delay } from "@std/async";
-import { TestServer } from "../server/tests/helpers/server.ts";
-import type { FrameMessage } from "../server/tests/helpers/types.ts";
-import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { pollResize } from "./helpers/arf_poll.ts";
+import {
+  createTwoBasePlots,
+  sendPlotIndexResizeAndPoll,
+  sendResizeAndPoll,
+  startArfBrowserTest,
+  waitForResizeFrame,
+} from "./helpers/arf_e2e.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
-import { toRSocketAddress } from "./helpers/r_process.ts";
+import { checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
@@ -30,51 +31,24 @@ Deno.test({
   async fn() {
     testLog("test start");
     testLog("plotindex_e2e_test start");
-    const server = new TestServer({ tcp: true });
-    const browser = new AutoMetricsBrowserClient();
-    const arf = new ArfSession();
+    const ctx = await startArfBrowserTest();
 
     try {
-      await server.start();
-      await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
       testLog("server/browser connected and initial resize sent");
-
-      testLog("arf.start begin");
-      await arf.start({ timeoutMs: 15_000 });
-      testLog("arf.start done");
-      const socketAddr = toRSocketAddress(server.socketPath);
-      testLog("jgd device setup begin");
-      await arf.eval(
-        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
-        15_000,
-      );
       testLog("plot generation begin");
-      await arf.eval("plot(1:3); plot(4:6)");
+      const [frame1, frame2] = await createTwoBasePlots(ctx);
       testLog("R device initialized and two plots generated");
-
-      // Wait for both frames
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
-      assert(frame1.plot.ops.length > 0, "First frame should have ops");
       testLog("received frame1");
-
-      const frame2 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame2.plot.ops.length > 0, "Second frame should have ops");
       testLog("received frame2");
 
       // --- Test 1: plotIndex=0 resize re-renders the first plot ---
       const sessionId = frame1.plot.sessionId!;
-      browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
-      await browser.sendPing(3000);
+      await sendPlotIndexResizeAndPoll(ctx, 640, 480, 0, sessionId);
       testLog("sent resize with plotIndex=0; calling poll_resize");
-      await pollResize(arf, 40);
       testLog("poll_resize returned for plotIndex=0");
 
-      const resized0 = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        6000,
-      );
+      const resized0 = await waitForResizeFrame(ctx.browser);
       testLog("received resized frame for plotIndex=0");
 
       assertEquals(
@@ -101,16 +75,11 @@ Deno.test({
       // (plot 2).  plotIndex=1 exceeds the snapshot count, so R falls
       // through to a normal resize of the current display list.  The frame
       // should have resize:true but no plotIndex.
-      browser.sendResizeWithPlotIndex(700, 500, 1, sessionId);
-      await browser.sendPing(3000);
+      await sendPlotIndexResizeAndPoll(ctx, 700, 500, 1, sessionId);
       testLog("sent resize with plotIndex=1; calling poll_resize");
-      await pollResize(arf, 40);
       testLog("poll_resize returned for plotIndex=1");
 
-      const resized1 = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        6000,
-      );
+      const resized1 = await waitForResizeFrame(ctx.browser);
       testLog("received resized frame for plotIndex=1/latest");
 
       assertEquals(
@@ -140,16 +109,11 @@ Deno.test({
       );
 
       // --- Test 3: normal resize (no plotIndex) still works ---
-      browser.sendResize(750, 550);
-      await browser.sendPing(3000);
+      await sendResizeAndPoll(ctx, 750, 550);
       testLog("sent normal resize; calling poll_resize");
-      await pollResize(arf, 40);
       testLog("poll_resize returned for normal resize");
 
-      const normalResize = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        6000,
-      );
+      const normalResize = await waitForResizeFrame(ctx.browser);
       testLog("received normal resize frame");
 
       assertEquals(
@@ -178,12 +142,8 @@ Deno.test({
       testLog("plotindex_e2e_test assertions complete");
     } finally {
       testLog("plotindex_e2e_test cleanup start");
-      browser.close();
-      await delay(100);
-      await server.shutdown();
+      await ctx.close();
       testLog("plotindex_e2e_test server shutdown done");
-      server.cleanup();
-      await arf.shutdown();
       testLog("plotindex_e2e_test cleanup done");
     }
   },

--- a/tests/plotindex_e2e_test.ts
+++ b/tests/plotindex_e2e_test.ts
@@ -16,16 +16,19 @@ import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
   name: "E2E: plotIndex resize re-renders historical plot",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -33,97 +36,129 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
-      // Start R with two plots + polling loop to keep the device open
-      // and responsive to resize messages.  Rscript (batch mode) does not
-      // process R input handlers during Sys.sleep, so we poll explicitly.
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); plot(1:3); plot(4:6); for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+      await arf.eval("plot(1:3); plot(4:6)");
+
+      // Wait for both frames
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame1.plot.ops.length > 0, "First frame should have ops");
+
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame2.plot.ops.length > 0, "Second frame should have ops");
+
+      // --- Test 1: plotIndex=0 resize re-renders the first plot ---
+      const sessionId = frame1.plot.sessionId!;
+      browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      const resized0 = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
       );
 
-      try {
-        // Wait for both frames
-        const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame1.plot.ops.length > 0, "First frame should have ops");
+      assertEquals(
+        resized0.resize,
+        true,
+        "plotIndex=0 frame should have resize:true",
+      );
+      assertEquals(
+        resized0.plotIndex,
+        0,
+        "plotIndex=0 frame should have plotIndex:0",
+      );
+      assert(resized0.plot.ops.length > 0, "plotIndex=0 frame should have ops");
 
-        const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame2.plot.ops.length > 0, "Second frame should have ops");
+      // The re-rendered frame should contain text from plot(1:3), not plot(4:6)
+      const texts0 = extractTextOps(resized0);
+      assert(
+        texts0.length > 0,
+        "plotIndex=0 re-render should contain text ops",
+      );
 
-        // --- Test 1: plotIndex=0 resize re-renders the first plot ---
-        const sessionId = frame1.plot.sessionId!;
-        browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
+      // --- Test 2: plotIndex=1 is the latest plot (no snapshot exists) ---
+      // With 2 plots, R has 1 snapshot (plot 1) and the active display list
+      // (plot 2).  plotIndex=1 exceeds the snapshot count, so R falls
+      // through to a normal resize of the current display list.  The frame
+      // should have resize:true but no plotIndex.
+      browser.sendResizeWithPlotIndex(700, 500, 1, sessionId);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        const resized0 = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
+      const resized1 = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
+      );
 
-        assertEquals(resized0.resize, true, "plotIndex=0 frame should have resize:true");
-        assertEquals(resized0.plotIndex, 0, "plotIndex=0 frame should have plotIndex:0");
-        assert(resized0.plot.ops.length > 0, "plotIndex=0 frame should have ops");
+      assertEquals(
+        resized1.resize,
+        true,
+        "plotIndex=1 frame should have resize:true",
+      );
+      assertEquals(
+        resized1.plotIndex,
+        undefined,
+        "plotIndex=1 targets the latest plot (no snapshot) — R treats as normal resize",
+      );
+      assert(resized1.plot.ops.length > 0, "plotIndex=1 frame should have ops");
 
-        // The re-rendered frame should contain text from plot(1:3), not plot(4:6)
-        const texts0 = extractTextOps(resized0);
-        assert(texts0.length > 0, "plotIndex=0 re-render should contain text ops");
+      const texts1 = extractTextOps(resized1);
+      assert(
+        texts1.length > 0,
+        "plotIndex=1 re-render should contain text ops",
+      );
 
-        // --- Test 2: plotIndex=1 is the latest plot (no snapshot exists) ---
-        // With 2 plots, R has 1 snapshot (plot 1) and the active display list
-        // (plot 2).  plotIndex=1 exceeds the snapshot count, so R falls
-        // through to a normal resize of the current display list.  The frame
-        // should have resize:true but no plotIndex.
-        browser.sendResizeWithPlotIndex(700, 500, 1, sessionId);
+      // plot(1:3) and plot(4:6) produce different axis labels, so the
+      // text ops from plotIndex=0 and plotIndex=1 should differ.
+      assertNotEquals(
+        JSON.stringify(texts0),
+        JSON.stringify(texts1),
+        "plotIndex=0 and plotIndex=1 should produce different text ops (different plots)",
+      );
 
-        const resized1 = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
+      // --- Test 3: normal resize (no plotIndex) still works ---
+      browser.sendResize(750, 550);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        assertEquals(resized1.resize, true, "plotIndex=1 frame should have resize:true");
-        assertEquals(resized1.plotIndex, undefined,
-          "plotIndex=1 targets the latest plot (no snapshot) — R treats as normal resize");
-        assert(resized1.plot.ops.length > 0, "plotIndex=1 frame should have ops");
+      const normalResize = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
+      );
 
-        const texts1 = extractTextOps(resized1);
-        assert(texts1.length > 0, "plotIndex=1 re-render should contain text ops");
+      assertEquals(
+        normalResize.resize,
+        true,
+        "Normal resize frame should have resize:true",
+      );
+      assertEquals(
+        normalResize.plotIndex,
+        undefined,
+        "Normal resize should NOT have plotIndex",
+      );
+      assert(
+        normalResize.plot.ops.length > 0,
+        "Normal resize frame should have ops",
+      );
 
-        // plot(1:3) and plot(4:6) produce different axis labels, so the
-        // text ops from plotIndex=0 and plotIndex=1 should differ.
-        assertNotEquals(
-          JSON.stringify(texts0),
-          JSON.stringify(texts1),
-          "plotIndex=0 and plotIndex=1 should produce different text ops (different plots)",
-        );
-
-        // --- Test 3: normal resize (no plotIndex) still works ---
-        browser.sendResize(750, 550);
-
-        const normalResize = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
-
-        assertEquals(normalResize.resize, true, "Normal resize frame should have resize:true");
-        assertEquals(normalResize.plotIndex, undefined, "Normal resize should NOT have plotIndex");
-        assert(normalResize.plot.ops.length > 0, "Normal resize frame should have ops");
-
-        // Normal resize re-renders the current (latest) plot, which is plot(4:6).
-        // Its text ops should match the plotIndex=1 response (also the latest plot).
-        const textsNormal = extractTextOps(normalResize);
-        assertEquals(
-          JSON.stringify(textsNormal),
-          JSON.stringify(texts1),
-          "Normal resize should re-render the current (latest) plot, matching plotIndex=1",
-        );
-      } finally {
-        r.kill();
-        // Drain process output to avoid resource leaks
-        try { await r.process.output(); } catch { /* ignore */ }
-      }
+      // Normal resize re-renders the current (latest) plot, which is plot(4:6).
+      // Its text ops should match the plotIndex=1 response (also the latest plot).
+      const textsNormal = extractTextOps(normalResize);
+      assertEquals(
+        JSON.stringify(textsNormal),
+        JSON.stringify(texts1),
+        "Normal resize should re-render the current (latest) plot, matching plotIndex=1",
+      );
     } finally {
       browser.close();
       await delay(100);
       await server.shutdown();
       server.cleanup();
+      await arf.shutdown();
     }
   },
 });

--- a/tests/plotindex_extra_frame_test.ts
+++ b/tests/plotindex_extra_frame_test.ts
@@ -107,7 +107,7 @@ Deno.test({
         browser.waitForType<FrameMessage>("frame", 6000, ac.signal).catch(() =>
           null
         ),
-        browser.sendPing(6000).then(() => {
+        browser.sendPing(3000).then(() => {
           ac.abort();
           return sentinel;
         }),

--- a/tests/plotindex_extra_frame_test.ts
+++ b/tests/plotindex_extra_frame_test.ts
@@ -20,6 +20,7 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
@@ -70,8 +71,8 @@ Deno.test({
       // At the protocol level, this is a resize with plotIndex=0.
       const sessionId = frame1.plot.sessionId!;
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
-      await delay(100); // allow WS message to propagate to server
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       // Wait for the resize response frame
       const resized = await browser.waitForMessage<FrameMessage>(

--- a/tests/plotindex_extra_frame_test.ts
+++ b/tests/plotindex_extra_frame_test.ts
@@ -21,11 +21,11 @@ import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name: "E2E: plotIndex resize produces exactly one frame with correct content",

--- a/tests/plotindex_extra_frame_test.ts
+++ b/tests/plotindex_extra_frame_test.ts
@@ -23,6 +23,7 @@ import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
@@ -31,6 +32,7 @@ Deno.test({
   name: "E2E: plotIndex resize produces exactly one frame with correct content",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/plotindex_extra_frame_test.ts
+++ b/tests/plotindex_extra_frame_test.ts
@@ -39,7 +39,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -49,11 +49,11 @@ Deno.test({
       await arf.eval("plot(1:3); plot(4:6)");
 
       // Wait for both plot frames
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame1.plot.ops.length > 0, "First frame should have ops");
       const texts1 = extractTextOps(frame1);
 
-      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame2.plot.ops.length > 0, "Second frame should have ops");
       const texts2 = extractTextOps(frame2);
 
@@ -74,7 +74,7 @@ Deno.test({
       // Wait for the resize response frame
       const resized = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
 
       assertEquals(resized.resize, true, "Should have resize:true");
@@ -102,10 +102,10 @@ Deno.test({
       const ac = new AbortController();
       const sentinel = Symbol("pong");
       const extraFrame = await Promise.race([
-        browser.waitForType<FrameMessage>("frame", 10000, ac.signal).catch(() =>
+        browser.waitForType<FrameMessage>("frame", 6000, ac.signal).catch(() =>
           null
         ),
-        browser.sendPing(5000).then(() => {
+        browser.sendPing(2000).then(() => {
           ac.abort();
           return sentinel;
         }),

--- a/tests/plotindex_extra_frame_test.ts
+++ b/tests/plotindex_extra_frame_test.ts
@@ -15,15 +15,16 @@
  *  - No extra frame leaks after the resize
  */
 
-import { assert, assertEquals, assertNotEquals } from "@std/assert";
-import { delay } from "@std/async";
-import { TestServer } from "../server/tests/helpers/server.ts";
-import type { FrameMessage } from "../server/tests/helpers/types.ts";
-import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { pollResize } from "./helpers/arf_poll.ts";
+import { assertEquals, assertNotEquals } from "@std/assert";
+import {
+  assertNoExtraFrameBeforePong,
+  createTwoBasePlots,
+  sendPlotIndexResizeAndPoll,
+  startArfBrowserTest,
+  waitForResizeFrame,
+} from "./helpers/arf_e2e.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
-import { toRSocketAddress } from "./helpers/r_process.ts";
+import { checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
@@ -34,30 +35,12 @@ Deno.test({
   ignore: skip,
   async fn() {
     testLog("test start");
-    const server = new TestServer({ tcp: true });
-    const browser = new AutoMetricsBrowserClient();
-    const arf = new ArfSession();
+    const ctx = await startArfBrowserTest();
+    const { browser } = ctx;
 
     try {
-      await server.start();
-      await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
-      await arf.start();
-      const socketAddr = toRSocketAddress(server.socketPath);
-      await arf.eval(
-        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
-      );
-      await arf.eval("plot(1:3); plot(4:6)");
-
-      // Wait for both plot frames
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
-      assert(frame1.plot.ops.length > 0, "First frame should have ops");
+      const [frame1, frame2] = await createTwoBasePlots(ctx);
       const texts1 = extractTextOps(frame1);
-
-      const frame2 = await browser.waitForType<FrameMessage>("frame", 8000);
-      assert(frame2.plot.ops.length > 0, "Second frame should have ops");
       const texts2 = extractTextOps(frame2);
 
       // Verify the two plots are different
@@ -70,15 +53,10 @@ Deno.test({
       // Simulate: navigate to plot 1, then resize.
       // At the protocol level, this is a resize with plotIndex=0.
       const sessionId = frame1.plot.sessionId!;
-      browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
-      await browser.sendPing(3000);
-      await pollResize(arf, 40);
+      await sendPlotIndexResizeAndPoll(ctx, 640, 480, 0, sessionId);
 
       // Wait for the resize response frame
-      const resized = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        6000,
-      );
+      const resized = await waitForResizeFrame(browser);
 
       assertEquals(resized.resize, true, "Should have resize:true");
       assertEquals(resized.plotIndex, 0, "Should have plotIndex:0");
@@ -102,29 +80,12 @@ Deno.test({
       // against a frame waiter — if the pong wins, no extra frame arrived.
       // AbortController cancels the losing waiter so it doesn't consume
       // later messages.
-      const ac = new AbortController();
-      const sentinel = Symbol("pong");
-      const extraFrame = await Promise.race([
-        browser.waitForType<FrameMessage>("frame", 6000, ac.signal).catch(() =>
-          null
-        ),
-        browser.sendPing(3000).then(() => {
-          ac.abort();
-          return sentinel;
-        }),
-      ]);
-
-      assertEquals(
-        extraFrame,
-        sentinel,
+      await assertNoExtraFrameBeforePong(
+        browser,
         "No extra frame should arrive after plotIndex resize (would create spurious plot 3)",
       );
     } finally {
-      browser.close();
-      await delay(100);
-      await server.shutdown();
-      server.cleanup();
-      await arf.shutdown();
+      await ctx.close();
     }
   },
 });

--- a/tests/plotindex_extra_frame_test.ts
+++ b/tests/plotindex_extra_frame_test.ts
@@ -21,16 +21,19 @@ import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
   name: "E2E: plotIndex resize produces exactly one frame with correct content",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -38,82 +41,87 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); plot(1:3); plot(4:6); for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+      await arf.eval("plot(1:3); plot(4:6)");
+
+      // Wait for both plot frames
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame1.plot.ops.length > 0, "First frame should have ops");
+      const texts1 = extractTextOps(frame1);
+
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame2.plot.ops.length > 0, "Second frame should have ops");
+      const texts2 = extractTextOps(frame2);
+
+      // Verify the two plots are different
+      assertNotEquals(
+        JSON.stringify(texts1),
+        JSON.stringify(texts2),
+        "Plot 1 and plot 2 should have different text ops",
       );
 
-      try {
-        // Wait for both plot frames
-        const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame1.plot.ops.length > 0, "First frame should have ops");
-        const texts1 = extractTextOps(frame1);
+      // Simulate: navigate to plot 1, then resize.
+      // At the protocol level, this is a resize with plotIndex=0.
+      const sessionId = frame1.plot.sessionId!;
+      browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame2.plot.ops.length > 0, "Second frame should have ops");
-        const texts2 = extractTextOps(frame2);
+      // Wait for the resize response frame
+      const resized = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
+      );
 
-        // Verify the two plots are different
-        assertNotEquals(
-          JSON.stringify(texts1),
-          JSON.stringify(texts2),
-          "Plot 1 and plot 2 should have different text ops",
-        );
+      assertEquals(resized.resize, true, "Should have resize:true");
+      assertEquals(resized.plotIndex, 0, "Should have plotIndex:0");
 
-        // Simulate: navigate to plot 1, then resize.
-        // At the protocol level, this is a resize with plotIndex=0.
-        const sessionId = frame1.plot.sessionId!;
-        browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
+      // CRITICAL: The resized frame must contain plot 1's content, not plot 2's.
+      // Bug 1 manifests as the frame containing plot 2's content because the
+      // snapshot replay produces the wrong plot.
+      const textsResized = extractTextOps(resized);
+      assertEquals(
+        JSON.stringify(textsResized),
+        JSON.stringify(texts1),
+        "plotIndex=0 resize should render plot 1's content, not plot 2's",
+      );
 
-        // Wait for the resize response frame
-        const resized = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
+      // CRITICAL: No extra frames should arrive after the resize.
+      // Bug 1 also manifests as the current plot restoration leaking an
+      // extra untagged frame, which the browser would treat as a new plot 3.
+      //
+      // Send a ping sentinel: because WebSocket messages are ordered, any
+      // frame queued before the pong will arrive first.  Race the pong
+      // against a frame waiter — if the pong wins, no extra frame arrived.
+      // AbortController cancels the losing waiter so it doesn't consume
+      // later messages.
+      const ac = new AbortController();
+      const sentinel = Symbol("pong");
+      const extraFrame = await Promise.race([
+        browser.waitForType<FrameMessage>("frame", 10000, ac.signal).catch(() =>
+          null
+        ),
+        browser.sendPing(5000).then(() => {
+          ac.abort();
+          return sentinel;
+        }),
+      ]);
 
-        assertEquals(resized.resize, true, "Should have resize:true");
-        assertEquals(resized.plotIndex, 0, "Should have plotIndex:0");
-
-        // CRITICAL: The resized frame must contain plot 1's content, not plot 2's.
-        // Bug 1 manifests as the frame containing plot 2's content because the
-        // snapshot replay produces the wrong plot.
-        const textsResized = extractTextOps(resized);
-        assertEquals(
-          JSON.stringify(textsResized),
-          JSON.stringify(texts1),
-          "plotIndex=0 resize should render plot 1's content, not plot 2's",
-        );
-
-        // CRITICAL: No extra frames should arrive after the resize.
-        // Bug 1 also manifests as the current plot restoration leaking an
-        // extra untagged frame, which the browser would treat as a new plot 3.
-        //
-        // Send a ping sentinel: because WebSocket messages are ordered, any
-        // frame queued before the pong will arrive first.  Race the pong
-        // against a frame waiter — if the pong wins, no extra frame arrived.
-        // AbortController cancels the losing waiter so it doesn't consume
-        // later messages.
-        const ac = new AbortController();
-        const sentinel = Symbol("pong");
-        const extraFrame = await Promise.race([
-          browser.waitForType<FrameMessage>("frame", 10000, ac.signal).catch(() => null),
-          browser.sendPing(5000).then(() => { ac.abort(); return sentinel; }),
-        ]);
-
-        assertEquals(
-          extraFrame,
-          sentinel,
-          "No extra frame should arrive after plotIndex resize (would create spurious plot 3)",
-        );
-      } finally {
-        r.kill();
-        try { await r.process.output(); } catch { /* ignore */ }
-      }
+      assertEquals(
+        extraFrame,
+        sentinel,
+        "No extra frame should arrive after plotIndex resize (would create spurious plot 3)",
+      );
     } finally {
       browser.close();
       await delay(100);
       await server.shutdown();
       server.cleanup();
+      await arf.shutdown();
     }
   },
 });

--- a/tests/plotindex_extra_frame_test.ts
+++ b/tests/plotindex_extra_frame_test.ts
@@ -105,7 +105,7 @@ Deno.test({
         browser.waitForType<FrameMessage>("frame", 6000, ac.signal).catch(() =>
           null
         ),
-        browser.sendPing(2000).then(() => {
+        browser.sendPing(6000).then(() => {
           ac.abort();
           return sentinel;
         }),

--- a/tests/plotindex_grid_contamination_test.ts
+++ b/tests/plotindex_grid_contamination_test.ts
@@ -137,6 +137,7 @@ Deno.test({
     } finally {
       await browser.close();
       await server.shutdown();
+      server.cleanup();
       await arf.shutdown();
     }
   },

--- a/tests/plotindex_grid_contamination_test.ts
+++ b/tests/plotindex_grid_contamination_test.ts
@@ -42,9 +42,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
 

--- a/tests/plotindex_grid_contamination_test.ts
+++ b/tests/plotindex_grid_contamination_test.ts
@@ -21,26 +21,12 @@ import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { checkGgplot2Available } from "./helpers/r_packages.ts";
 import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const ggplot2Available = arfTestAvailable && await checkGgplot2Available();
 const skip = !ggplot2Available;
-
-async function checkGgplot2Available(): Promise<boolean> {
-  try {
-    const cmd = new Deno.Command("Rscript", {
-      args: ["-e", 'library(ggplot2); cat("ok")'],
-      stdout: "piped",
-      stderr: "piped",
-    });
-    const output = await cmd.output();
-    const stdout = new TextDecoder().decode(output.stdout);
-    return output.success && stdout.includes("ok");
-  } catch {
-    return false;
-  }
-}
 
 Deno.test({
   name:

--- a/tests/plotindex_grid_contamination_test.ts
+++ b/tests/plotindex_grid_contamination_test.ts
@@ -38,7 +38,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -65,7 +65,7 @@ Deno.test({
       const deadline = Date.now() + 20000;
 
       while (newPageCount < 3 && Date.now() < deadline) {
-        const msg = await browser.waitForType<FrameMessage>("frame", 10000);
+        const msg = await browser.waitForType<FrameMessage>("frame", 6000);
         frames.push(msg);
         if (msg.newPage) newPageCount++;
       }
@@ -97,7 +97,7 @@ Deno.test({
 
       const resized = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
 
       assertEquals(

--- a/tests/plotindex_grid_contamination_test.ts
+++ b/tests/plotindex_grid_contamination_test.ts
@@ -18,6 +18,7 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
@@ -96,8 +97,8 @@ Deno.test({
       // plotIndex 0 = ggplot2 (plot 1), plotIndex 1 = base plot (plot 2)
       // Use plotIndex 1 to resize the base plot.
       browser.sendResizeWithPlotIndex(640, 480, 1, sessionId);
-      await delay(100);
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const resized = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,

--- a/tests/plotindex_grid_contamination_test.ts
+++ b/tests/plotindex_grid_contamination_test.ts
@@ -19,11 +19,11 @@ import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name:

--- a/tests/plotindex_grid_contamination_test.ts
+++ b/tests/plotindex_grid_contamination_test.ts
@@ -21,6 +21,7 @@ import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const ggplot2Available = arfTestAvailable && await checkGgplot2Available();
@@ -46,6 +47,7 @@ Deno.test({
     "E2E: plotIndex resize of base plot after ggplot2 shows correct content",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/plotindex_grid_contamination_test.ts
+++ b/tests/plotindex_grid_contamination_test.ts
@@ -19,16 +19,20 @@ import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
-  name: "E2E: plotIndex resize of base plot after ggplot2 shows correct content",
-  ignore: !rAvailable,
+  name:
+    "E2E: plotIndex resize of base plot after ggplot2 shows correct content",
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -36,102 +40,100 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      // Setup: connect jgd device
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+
       // Plot 1: ggplot2 (grid-based, populates grid state)
-      // Plot 2: base-graphics plot(1:3) with ext
-      // Plot 3: another base plot (pushes plot 2 to snapshot history)
-      // Then poll for resize.
-      const rCode = [
-        "jgd(width=8, height=6, dpi=96)",
-        "library(ggplot2)",
-        "ggplot(mpg, aes(displ, hwy)) + geom_point()",
-        'jgd_ext(\'{"shadow":{"blur":5}}\')',
-        "plot(1:3)",
-        "jgd_ext(NULL)",
-        "plot(4:6)",
-        "for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }",
-      ].join("; ");
+      await arf.eval(
+        "library(ggplot2); ggplot(mpg, aes(displ, hwy)) + geom_point()",
+      );
 
-      const r = startR(rCode, server.socketPath);
+      // Plot 2: base-graphics plot(1:3) with ext; Plot 3: another base plot
+      await arf.eval(
+        'jgd_ext(\'{"shadow":{"blur":5}}\'); plot(1:3); jgd_ext(NULL); plot(4:6)',
+      );
 
-      try {
-        // Collect all frames until we have at least 3 newPage frames
-        // (ggplot2 sends many incremental frames before the base plot's newPage)
-        const frames: FrameMessage[] = [];
-        let newPageCount = 0;
-        const deadline = Date.now() + 20000;
+      // Collect all frames until we have at least 3 newPage frames
+      // (ggplot2 sends many incremental frames before the base plot's newPage)
+      const frames: FrameMessage[] = [];
+      let newPageCount = 0;
+      const deadline = Date.now() + 20000;
 
-        while (newPageCount < 3 && Date.now() < deadline) {
-          const msg = await browser.waitForType<FrameMessage>("frame", 10000);
-          frames.push(msg);
-          if (msg.newPage) newPageCount++;
-        }
-
-        assert(
-          newPageCount >= 3,
-          `Expected at least 3 newPage frames, got ${newPageCount}`,
-        );
-
-        // Find the newPage frames: [ggplot2, base plot(1:3), plot(4:6)]
-        const newPageFrames = frames.filter((f) => f.newPage);
-        const basePlotFrame = newPageFrames[1]; // plot(1:3) is the second newPage
-
-        // The base plot (plot(1:3)) should have text labels "1", "2", "3"
-        const baseTexts = extractTextOps(basePlotFrame);
-        assert(
-          baseTexts.some((t) => t.includes("1")),
-          `Base plot frame should contain "1", got: ${JSON.stringify(baseTexts)}`,
-        );
-
-        // Get sessionId for plotIndex resize
-        const sessionId = basePlotFrame.plot.sessionId!;
-
-        // plotIndex 0 = ggplot2 (plot 1), plotIndex 1 = base plot (plot 2)
-        // Use plotIndex 1 to resize the base plot.
-        browser.sendResizeWithPlotIndex(640, 480, 1, sessionId);
-
-        const resized = await browser.waitForMessage<FrameMessage>(
-          (msg) =>
-            msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
-
-        assertEquals(
-          resized.resize,
-          true,
-          "Resized frame should have resize:true",
-        );
-        assertEquals(
-          resized.plotIndex,
-          1,
-          "Resized frame should have plotIndex=1",
-        );
-
-        // The resized frame must contain base plot text ops ("1", "2", "3"),
-        // NOT ggplot2 content ("displ", "hwy", etc.)
-        const resizedTexts = extractTextOps(resized);
-        assert(
-          resizedTexts.some((t) => t.includes("1")),
-          `Resized plot should contain "1", got: ${JSON.stringify(resizedTexts)}`,
-        );
-
-        // Must NOT contain ggplot2 axis labels
-        const hasGgplotContent = resizedTexts.some(
-          (t) => t.includes("displ") || t.includes("hwy"),
-        );
-        assertEquals(
-          hasGgplotContent,
-          false,
-          `Resized plot must NOT contain ggplot2 content, got: ${JSON.stringify(resizedTexts)}`,
-        );
-      } finally {
-        r.kill();
-        // Drain stdio to avoid resource leaks
-        await r.process.stdout.cancel();
-        await r.process.stderr.cancel();
+      while (newPageCount < 3 && Date.now() < deadline) {
+        const msg = await browser.waitForType<FrameMessage>("frame", 10000);
+        frames.push(msg);
+        if (msg.newPage) newPageCount++;
       }
+
+      assert(
+        newPageCount >= 3,
+        `Expected at least 3 newPage frames, got ${newPageCount}`,
+      );
+
+      // Find the newPage frames: [ggplot2, base plot(1:3), plot(4:6)]
+      const newPageFrames = frames.filter((f) => f.newPage);
+      const basePlotFrame = newPageFrames[1]; // plot(1:3) is the second newPage
+
+      // The base plot (plot(1:3)) should have text labels "1", "2", "3"
+      const baseTexts = extractTextOps(basePlotFrame);
+      assert(
+        baseTexts.some((t) => t.includes("1")),
+        `Base plot frame should contain "1", got: ${JSON.stringify(baseTexts)}`,
+      );
+
+      // Get sessionId for plotIndex resize
+      const sessionId = basePlotFrame.plot.sessionId!;
+
+      // plotIndex 0 = ggplot2 (plot 1), plotIndex 1 = base plot (plot 2)
+      // Use plotIndex 1 to resize the base plot.
+      browser.sendResizeWithPlotIndex(640, 480, 1, sessionId);
+      await delay(100);
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      const resized = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
+      );
+
+      assertEquals(
+        resized.resize,
+        true,
+        "Resized frame should have resize:true",
+      );
+      assertEquals(
+        resized.plotIndex,
+        1,
+        "Resized frame should have plotIndex=1",
+      );
+
+      // The resized frame must contain base plot text ops ("1", "2", "3"),
+      // NOT ggplot2 content ("displ", "hwy", etc.)
+      const resizedTexts = extractTextOps(resized);
+      assert(
+        resizedTexts.some((t) => t.includes("1")),
+        `Resized plot should contain "1", got: ${JSON.stringify(resizedTexts)}`,
+      );
+
+      // Must NOT contain ggplot2 axis labels
+      const hasGgplotContent = resizedTexts.some(
+        (t) => t.includes("displ") || t.includes("hwy"),
+      );
+      assertEquals(
+        hasGgplotContent,
+        false,
+        `Resized plot must NOT contain ggplot2 content, got: ${
+          JSON.stringify(resizedTexts)
+        }`,
+      );
     } finally {
       await browser.close();
       await server.shutdown();
+      await arf.shutdown();
     }
   },
 });

--- a/tests/plotindex_grid_contamination_test.ts
+++ b/tests/plotindex_grid_contamination_test.ts
@@ -23,7 +23,23 @@ import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
-const skip = !arfTestAvailable;
+const ggplot2Available = arfTestAvailable && await checkGgplot2Available();
+const skip = !ggplot2Available;
+
+async function checkGgplot2Available(): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command("Rscript", {
+      args: ["-e", 'library(ggplot2); cat("ok")'],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const output = await cmd.output();
+    const stdout = new TextDecoder().decode(output.stdout);
+    return output.success && stdout.includes("ok");
+  } catch {
+    return false;
+  }
+}
 
 Deno.test({
   name:

--- a/tests/plotindex_grid_contamination_test.ts
+++ b/tests/plotindex_grid_contamination_test.ts
@@ -68,7 +68,7 @@ Deno.test({
 
       // Plot 1: ggplot2 (grid-based, populates grid state)
       await arf.eval(
-        "library(ggplot2); ggplot(mpg, aes(displ, hwy)) + geom_point()",
+        "library(ggplot2); print(ggplot(mpg, aes(displ, hwy)) + geom_point())",
       );
 
       // Plot 2: base-graphics plot(1:3) with ext; Plot 3: another base plot

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -62,6 +62,20 @@ function hasRedLineOp(frames: FrameMessage[]): boolean {
   return false;
 }
 
+async function canvasAlphaChecksum(
+  page: Awaited<ReturnType<E2EBrowser["newPage"]>>,
+): Promise<number> {
+  return await page.evaluate(`(function() {
+    var c = document.getElementById('plot-canvas');
+    if (!c || c.width === 0 || c.height === 0) return 0;
+    var ctx = c.getContext('2d');
+    var data = ctx.getImageData(0, 0, c.width, c.height).data;
+    var sum = 0;
+    for (var i = 3; i < data.length; i += 4) sum += data[i];
+    return sum;
+  })()`) as number;
+}
+
 Deno.test({
   name: "E2E: base graphics + lines() ops preserved after plotIndex resize",
   ignore: skip,
@@ -202,6 +216,7 @@ Deno.test({
         await canvasHasContent(page),
         "canvas should have content when viewing plot 1",
       );
+      const beforeResizeChecksum = await canvasAlphaChecksum(page);
 
       // Trigger resize — ResizeObserver fires with plotIndex=0 because we're
       // viewing a historical plot
@@ -217,14 +232,19 @@ Deno.test({
       // Explicitly process the resize in R (no embedded polling loop needed)
       await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-      // Wait for the browser to render the re-drawn frame
+      // Wait for a post-resize render signal before asserting non-blank.
+      // Content can already be non-blank due to local browser replay.
       const deadline = Date.now() + 5_000;
+      let changed = false;
       let hasContent = false;
       while (Date.now() < deadline) {
+        const checksum = await canvasAlphaChecksum(page);
         hasContent = await canvasHasContent(page);
-        if (hasContent) break;
+        if (checksum !== beforeResizeChecksum) changed = true;
+        if (changed && hasContent) break;
         await delay(100);
       }
+      assert(changed, "canvas should update after plotIndex resize replay");
       assert(hasContent, "canvas must not be blank after plotIndex resize");
 
       // Navigation state should be unchanged (still viewing plot 1 of 2)

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -25,6 +25,7 @@ import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { pollResize } from "./helpers/arf_poll.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { waitForWsConnected } from "./helpers/page_ready.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 
@@ -190,7 +191,9 @@ Deno.test({
       await e2e.launch();
       const page = await e2e.newPage(server.httpBaseUrl);
       await observer.connect(server.wsUrl);
-      await delay(500);
+      // Deterministic barrier: wait until the page's WebSocket onopen
+      // has actually fired so initial frames are not lost on slow CI.
+      await waitForWsConnected(page);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -228,9 +231,10 @@ Deno.test({
         c.style.height = '350px';
       })()`);
 
-      // Wait for the page's ResizeObserver debounce and then process the
-      // server-side resize message in R.
-      await delay(500);
+      // The page's ResizeObserver debounces resize sends by ~300ms, so the
+      // resize message may arrive in R's queue well after a single poll
+      // window closes. Keep polling R until the replay frame is observed
+      // (or the deadline expires), instead of relying on a fixed delay.
       const replayFramePromise = observer.waitForMessage<FrameMessage>(
         (msg) =>
           msg.type === "frame" &&
@@ -238,7 +242,14 @@ Deno.test({
           (msg as FrameMessage).plotIndex === 0,
         15_000,
       );
-      await pollResize(arf, 40);
+      let replayDone = false;
+      replayFramePromise.then(() => (replayDone = true)).catch(() =>
+        (replayDone = true)
+      );
+      const pollDeadline = Date.now() + 14_000;
+      while (!replayDone && Date.now() < pollDeadline) {
+        await pollResize(arf, 40);
+      }
       await replayFramePromise;
 
       // Wait for a post-resize render signal before asserting non-blank.

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -21,12 +21,12 @@ import {
 } from "../server/tests/helpers/e2e_browser.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 // ---------------------------------------------------------------------------
 // Layer 1: protocol-level assertions

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -22,6 +22,7 @@ import {
 } from "../server/tests/helpers/e2e_browser.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
@@ -123,10 +124,8 @@ Deno.test({
 
       // Request resize of historical plot 1 (plotIndex = 0)
       browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
-      await delay(100); // allow WS message to propagate to server → R socket
-
-      // Explicitly trigger poll — no polling loop needed with ArfSession
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const resized = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
@@ -183,6 +182,7 @@ Deno.test({
     testLog("test start");
     const server = new TestServer({ tcp: true });
     const e2e = new E2EBrowser();
+    const observer = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
 
     try {
@@ -191,6 +191,7 @@ Deno.test({
       // Launch browser before R so it receives frames in order
       await e2e.launch();
       const page = await e2e.newPage(server.httpBaseUrl);
+      await observer.connect(server.wsUrl);
       await delay(500);
 
       await arf.start();
@@ -229,11 +230,18 @@ Deno.test({
         c.style.height = '350px';
       })()`);
 
-      // Wait for debounce (300ms) + message propagation to R's socket
+      // Wait for the page's ResizeObserver debounce and then process the
+      // server-side resize message in R.
       await delay(500);
-
-      // Explicitly process the resize in R (no embedded polling loop needed)
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      const replayFramePromise = observer.waitForMessage<FrameMessage>(
+        (msg) =>
+          msg.type === "frame" &&
+          (msg as FrameMessage).resize === true &&
+          (msg as FrameMessage).plotIndex === 0,
+        15_000,
+      );
+      await pollResize(arf, 40);
+      await replayFramePromise;
 
       // Wait for a post-resize render signal before asserting non-blank.
       // Content can already be non-blank due to local browser replay.
@@ -258,6 +266,7 @@ Deno.test({
       );
     } finally {
       await arf.shutdown();
+      observer.close();
       await e2e.close();
       await delay(100);
       await server.shutdown();

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -1,0 +1,244 @@
+/**
+ * Historical plot resize tests using ArfSession for step-by-step R control.
+ *
+ * These tests cover scenarios where a plot is composed in multiple steps
+ * (e.g. plot() followed by lines()) and verify that all drawing ops survive
+ * a plotIndex resize of the historical plot.
+ *
+ * Two test layers:
+ *  Layer 1 — protocol-level (op count / type assertions, no browser needed)
+ *  Layer 2 — full-stack (real Chromium via Astral, canvas content validation)
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { delay } from "@std/async";
+import { TestServer } from "../server/tests/helpers/server.ts";
+import {
+  canvasHasContent,
+  E2EBrowser,
+  plotInfoText,
+  waitForPlotInfo,
+} from "../server/tests/helpers/e2e_browser.ts";
+import type { FrameMessage } from "../server/tests/helpers/types.ts";
+import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
+import { extractTextOps } from "./helpers/plot_ops.ts";
+
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
+
+// ---------------------------------------------------------------------------
+// Layer 1: protocol-level assertions
+// ---------------------------------------------------------------------------
+
+// Collect frames until quiet (no new frame within timeoutMs).
+// Used to gather both the newPage frame and any incremental frames.
+async function collectFramesUntilQuiet(
+  browser: AutoMetricsBrowserClient,
+  quietMs = 500,
+): Promise<FrameMessage[]> {
+  const frames: FrameMessage[] = [];
+  while (true) {
+    try {
+      frames.push(await browser.waitForType<FrameMessage>("frame", quietMs));
+    } catch {
+      break;
+    }
+  }
+  return frames;
+}
+
+function hasRedLineOp(frames: FrameMessage[]): boolean {
+  for (const frame of frames) {
+    for (const op of frame.plot.ops as Array<Record<string, unknown>>) {
+      if (op.op === "line" || op.op === "polyline") {
+        const gc = op.gc as Record<string, unknown> | null;
+        const col = ((gc?.col as string | undefined) ?? "").toLowerCase();
+        if (col.includes("ff0000") || col.includes("255,0,0")) return true;
+      }
+    }
+  }
+  return false;
+}
+
+Deno.test({
+  name: "E2E: base graphics + lines() ops preserved after plotIndex resize",
+  ignore: skip,
+  async fn() {
+    const server = new TestServer({ tcp: true });
+    const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
+
+    try {
+      await server.start();
+      await browser.connect(server.wsUrl);
+      browser.sendResize(800, 600);
+      await delay(200);
+
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+
+      // Plot 1: base plot + red lines() overlay.
+      // jgd sends lines() as a separate incremental frame, so we collect
+      // both the newPage frame and the incremental frame.
+      await arf.eval(
+        'plot(1:10, main="Plot 1"); lines(c(2, 5, 8), c(2, 5, 8), col="red", lwd=2)',
+      );
+      const plot1Frames = await collectFramesUntilQuiet(browser);
+      assert(
+        plot1Frames.length >= 2,
+        "plot 1 should produce newPage + incremental frames",
+      );
+      assert(
+        hasRedLineOp(plot1Frames),
+        "plot 1 frames must contain red line ops from lines()",
+      );
+
+      const sessionId = plot1Frames[0].plot.sessionId!;
+
+      // Plot 2: push plot 1 into history
+      await arf.eval('plot(11:20, main="Plot 2")');
+      await collectFramesUntilQuiet(browser);
+
+      // Request resize of historical plot 1 (plotIndex = 0)
+      browser.sendResizeWithPlotIndex(640, 480, 0, sessionId);
+      await delay(100); // allow WS message to propagate to server → R socket
+
+      // Explicitly trigger poll — no polling loop needed with ArfSession
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      const resized = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        15_000,
+      );
+
+      assertEquals(
+        resized.resize,
+        true,
+        "resized frame should have resize:true",
+      );
+      assertEquals(
+        resized.plotIndex,
+        0,
+        "resized frame should have plotIndex:0",
+      );
+      assert(resized.plot.ops.length > 0, "resized frame should have ops");
+
+      // Layer 1: plotIndex resize must replay the full display list,
+      // including the lines() ops (regression for jgd-c0f: lines() vanishing
+      // after resize of a historical plot).
+      assert(
+        hasRedLineOp([resized]),
+        "resized plot 1 must contain red line ops from lines() — regression for jgd-c0f",
+      );
+
+      // Text ops (axis labels, title) should match the newPage frame
+      const textsOriginal = extractTextOps(plot1Frames[0]);
+      const textsResized = extractTextOps(resized);
+      assertEquals(
+        JSON.stringify(textsOriginal),
+        JSON.stringify(textsResized),
+        "text ops must be the same before and after resize",
+      );
+    } finally {
+      await arf.shutdown();
+      browser.close();
+      await delay(100);
+      await server.shutdown();
+      server.cleanup();
+    }
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Layer 2: full-stack browser navigation test
+// ---------------------------------------------------------------------------
+
+Deno.test({
+  name:
+    "E2E: full-stack — browser navigation + plotIndex resize keeps canvas non-blank",
+  ignore: skip,
+  async fn() {
+    const server = new TestServer({ tcp: true });
+    const e2e = new E2EBrowser();
+    const arf = new ArfSession();
+
+    try {
+      await server.start();
+
+      // Launch browser before R so it receives frames in order
+      await e2e.launch();
+      const page = await e2e.newPage(server.httpBaseUrl);
+      await delay(500);
+
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+
+      // Plot 1: base plot + lines overlay
+      await arf.eval(
+        'plot(1:10, main="Plot 1"); lines(c(2, 5, 8), c(2, 5, 8), col="red", lwd=2)',
+      );
+      await waitForPlotInfo(page, "1 / 1", 15_000);
+
+      // Plot 2: push plot 1 into history
+      await arf.eval('plot(11:20, main="Plot 2")');
+      await waitForPlotInfo(page, "2 / 2", 15_000);
+
+      // Navigate back to plot 1 via the browser's ◀ button
+      await page.evaluate(`document.getElementById('btn-prev').click()`);
+      await waitForPlotInfo(page, "1 / 2", 5_000);
+
+      // Verify canvas has content while viewing plot 1
+      assert(
+        await canvasHasContent(page),
+        "canvas should have content when viewing plot 1",
+      );
+
+      // Trigger resize — ResizeObserver fires with plotIndex=0 because we're
+      // viewing a historical plot
+      await page.evaluate(`(function() {
+        var c = document.getElementById('canvas-container');
+        c.style.width = '500px';
+        c.style.height = '350px';
+      })()`);
+
+      // Wait for debounce (300ms) + message propagation to R's socket
+      await delay(500);
+
+      // Explicitly process the resize in R (no embedded polling loop needed)
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      // Wait for the browser to render the re-drawn frame
+      const deadline = Date.now() + 5_000;
+      let hasContent = false;
+      while (Date.now() < deadline) {
+        hasContent = await canvasHasContent(page);
+        if (hasContent) break;
+        await delay(100);
+      }
+      assert(hasContent, "canvas must not be blank after plotIndex resize");
+
+      // Navigation state should be unchanged (still viewing plot 1 of 2)
+      assertEquals(
+        await plotInfoText(page),
+        "1 / 2",
+        "should still be viewing plot 1 of 2 after resize",
+      );
+    } finally {
+      await arf.shutdown();
+      await e2e.close();
+      await delay(100);
+      await server.shutdown();
+      server.cleanup();
+    }
+  },
+});

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -20,6 +20,7 @@ import {
   plotInfoText,
   waitForPlotInfo,
 } from "../server/tests/helpers/e2e_browser.ts";
+import { BrowserClient } from "../server/tests/helpers/browser_client.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { pollResize } from "./helpers/arf_poll.ts";
@@ -182,7 +183,7 @@ Deno.test({
     testLog("test start");
     const server = new TestServer({ tcp: true });
     const e2e = new E2EBrowser();
-    const observer = new AutoMetricsBrowserClient();
+    const observer = new BrowserClient();
     const arf = new ArfSession();
 
     try {

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -239,14 +239,6 @@ Deno.test({
         "canvas should have foreground pixels when viewing plot 1",
       );
 
-      // Trigger resize — ResizeObserver fires with plotIndex=0 because we're
-      // viewing a historical plot
-      await page.evaluate(`(function() {
-        var c = document.getElementById('canvas-container');
-        c.style.width = '500px';
-        c.style.height = '350px';
-      })()`);
-
       // The page's ResizeObserver debounces resize sends by ~300ms, so the
       // resize message may arrive in R's queue well after a single poll
       // window closes. Keep polling R until the replay frame is observed
@@ -255,9 +247,19 @@ Deno.test({
         (msg) =>
           msg.type === "frame" &&
           (msg as FrameMessage).resize === true &&
+          (msg as FrameMessage).resizeReplay === true &&
           (msg as FrameMessage).plotIndex === 0,
         15_000,
       );
+
+      // Trigger resize — ResizeObserver fires with plotIndex=0 because we're
+      // viewing a historical plot. The replay waiter is already registered so
+      // it cannot be satisfied by a buffered frame from after this action.
+      await page.evaluate(`(function() {
+        var c = document.getElementById('canvas-container');
+        c.style.width = '500px';
+        c.style.height = '350px';
+      })()`);
       let replayDone = false;
       replayFramePromise.then(() => (replayDone = true)).catch(
         () => (replayDone = true),

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -66,18 +66,30 @@ function hasRedLineOp(frames: FrameMessage[]): boolean {
   return false;
 }
 
-async function canvasAlphaChecksum(
+async function canvasPaintStats(
   page: Awaited<ReturnType<E2EBrowser["newPage"]>>,
-): Promise<number> {
+): Promise<{ paintedPixels: number; checksum: number }> {
   return await page.evaluate(`(function() {
     var c = document.getElementById('plot-canvas');
-    if (!c || c.width === 0 || c.height === 0) return 0;
+    if (!c || c.width === 0 || c.height === 0) {
+      return { paintedPixels: 0, checksum: 0 };
+    }
     var ctx = c.getContext('2d');
     var data = ctx.getImageData(0, 0, c.width, c.height).data;
-    var sum = 0;
-    for (var i = 3; i < data.length; i += 4) sum += data[i];
-    return sum;
-  })()`) as number;
+    var paintedPixels = 0;
+    var checksum = 0;
+    for (var i = 0; i < data.length; i += 4) {
+      var r = data[i];
+      var g = data[i + 1];
+      var b = data[i + 2];
+      var a = data[i + 3];
+      if (a > 0 && (r < 245 || g < 245 || b < 245)) {
+        paintedPixels++;
+        checksum = (checksum + paintedPixels * (r + 3 * g + 7 * b + 11 * a)) % 1000000007;
+      }
+    }
+    return { paintedPixels: paintedPixels, checksum: checksum };
+  })()`) as { paintedPixels: number; checksum: number };
 }
 
 Deno.test({
@@ -221,7 +233,11 @@ Deno.test({
         await canvasHasContent(page),
         "canvas should have content when viewing plot 1",
       );
-      const beforeResizeChecksum = await canvasAlphaChecksum(page);
+      const beforeResizeStats = await canvasPaintStats(page);
+      assert(
+        beforeResizeStats.paintedPixels > 0,
+        "canvas should have foreground pixels when viewing plot 1",
+      );
 
       // Trigger resize — ResizeObserver fires with plotIndex=0 because we're
       // viewing a historical plot
@@ -243,8 +259,8 @@ Deno.test({
         15_000,
       );
       let replayDone = false;
-      replayFramePromise.then(() => (replayDone = true)).catch(() =>
-        (replayDone = true)
+      replayFramePromise.then(() => (replayDone = true)).catch(
+        () => (replayDone = true),
       );
       const pollDeadline = Date.now() + 14_000;
       while (!replayDone && Date.now() < pollDeadline) {
@@ -257,15 +273,21 @@ Deno.test({
       const deadline = Date.now() + 5_000;
       let changed = false;
       let hasContent = false;
+      let paintedPixels = 0;
       while (Date.now() < deadline) {
-        const checksum = await canvasAlphaChecksum(page);
+        const stats = await canvasPaintStats(page);
         hasContent = await canvasHasContent(page);
-        if (checksum !== beforeResizeChecksum) changed = true;
-        if (changed && hasContent) break;
+        paintedPixels = stats.paintedPixels;
+        if (stats.checksum !== beforeResizeStats.checksum) changed = true;
+        if (changed && hasContent && paintedPixels > 0) break;
         await delay(100);
       }
       assert(changed, "canvas should update after plotIndex resize replay");
       assert(hasContent, "canvas must not be blank after plotIndex resize");
+      assert(
+        paintedPixels > 0,
+        "canvas must contain foreground pixels after plotIndex resize",
+      );
 
       // Navigation state should be unchanged (still viewing plot 1 of 2)
       assertEquals(

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -13,6 +13,7 @@
 import { assert, assertEquals } from "@std/assert";
 import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
+import { testLog } from "./helpers/test_log.ts";
 import {
   canvasHasContent,
   E2EBrowser,
@@ -80,6 +81,7 @@ Deno.test({
   name: "E2E: base graphics + lines() ops preserved after plotIndex resize",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -178,6 +180,7 @@ Deno.test({
     "E2E: full-stack — browser navigation + plotIndex resize keeps canvas non-blank",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const e2e = new E2EBrowser();
     const arf = new ArfSession();

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -74,7 +74,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);

--- a/tests/plotindex_history_resize_test.ts
+++ b/tests/plotindex_history_resize_test.ts
@@ -91,9 +91,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
 

--- a/tests/plotindex_regression_test.ts
+++ b/tests/plotindex_regression_test.ts
@@ -19,6 +19,7 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
@@ -58,8 +59,8 @@ Deno.test({
 
       // Step 3: Normal resize — verify latest plot (plot 2) re-renders
       browser.sendResize(640, 480);
-      await delay(100); // allow WS message to propagate to server
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const normalResize1 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
@@ -84,8 +85,8 @@ Deno.test({
       // Step 5: plotIndex=0 resize — verify historical plot (plot 1) re-renders
       const sessionId = frame1.plot.sessionId!;
       browser.sendResizeWithPlotIndex(700, 500, 0, sessionId);
-      await delay(100); // allow WS message to propagate to server
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const plotIndexResize = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
@@ -118,8 +119,8 @@ Deno.test({
       // After plotIndex resize, a subsequent normal resize should
       // re-render the current (latest) plot.
       browser.sendResize(750, 550);
-      await delay(100); // allow WS message to propagate to server
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const normalResize2 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
@@ -193,8 +194,8 @@ Deno.test({
       // Normal resize AFTER R session is established to properly set
       // the server's lastResizeW/H dedup state.
       browser.sendResize(640, 480);
-      await delay(100); // allow WS message to propagate to server
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const firstNormal = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
@@ -207,8 +208,8 @@ Deno.test({
       // This bypasses dedup and updates lastResizeW/H to 700x500.
       // R's device dimensions are also changed to 700x500.
       browser.sendResizeWithPlotIndex(700, 500, 0, sessionId);
-      await delay(100); // allow WS message to propagate to server
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const plotIndexFrame = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
@@ -220,8 +221,8 @@ Deno.test({
       // is 700x500 (plotIndex resize updated dedup state), so 640x480
       // should be forwarded (different dims).
       browser.sendResize(640, 480);
-      await delay(100); // allow WS message to propagate to server
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const normalFrame = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,

--- a/tests/plotindex_regression_test.ts
+++ b/tests/plotindex_regression_test.ts
@@ -22,6 +22,7 @@ import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
@@ -30,6 +31,7 @@ Deno.test({
   name: "E2E: normal resize works after plotIndex resize (regression)",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -165,6 +167,7 @@ Deno.test({
   name: "E2E: normal resize not deduped when dims match pre-plotIndex state",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/plotindex_regression_test.ts
+++ b/tests/plotindex_regression_test.ts
@@ -20,11 +20,11 @@ import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name: "E2E: normal resize works after plotIndex resize (regression)",

--- a/tests/plotindex_regression_test.ts
+++ b/tests/plotindex_regression_test.ts
@@ -20,16 +20,19 @@ import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
   name: "E2E: normal resize works after plotIndex resize (regression)",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -37,105 +40,134 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); plot(1:3); plot(4:6); for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+      await arf.eval("plot(1:3); plot(4:6)");
+
+      // Step 1-2: Wait for both plots
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame1.plot.ops.length > 0, "First frame should have ops");
+
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame2.plot.ops.length > 0, "Second frame should have ops");
+
+      // Step 3: Normal resize — verify latest plot (plot 2) re-renders
+      browser.sendResize(640, 480);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      const normalResize1 = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
       );
 
-      try {
-        // Step 1-2: Wait for both plots
-        const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame1.plot.ops.length > 0, "First frame should have ops");
+      assertEquals(
+        normalResize1.resize,
+        true,
+        "Step 3: should have resize:true",
+      );
+      assertEquals(
+        normalResize1.plotIndex,
+        undefined,
+        "Step 3: should NOT have plotIndex",
+      );
+      assert(normalResize1.plot.ops.length > 0, "Step 3: should have ops");
 
-        const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame2.plot.ops.length > 0, "Second frame should have ops");
+      const textsStep3 = extractTextOps(normalResize1);
+      assert(textsStep3.length > 0, "Step 3: should have text ops");
 
-        // Step 3: Normal resize — verify latest plot (plot 2) re-renders
-        browser.sendResize(640, 480);
+      // Step 5: plotIndex=0 resize — verify historical plot (plot 1) re-renders
+      const sessionId = frame1.plot.sessionId!;
+      browser.sendResizeWithPlotIndex(700, 500, 0, sessionId);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        const normalResize1 = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
+      const plotIndexResize = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
+      );
 
-        assertEquals(normalResize1.resize, true, "Step 3: should have resize:true");
-        assertEquals(normalResize1.plotIndex, undefined, "Step 3: should NOT have plotIndex");
-        assert(normalResize1.plot.ops.length > 0, "Step 3: should have ops");
+      assertEquals(
+        plotIndexResize.resize,
+        true,
+        "Step 5: should have resize:true",
+      );
+      assertEquals(
+        plotIndexResize.plotIndex,
+        0,
+        "Step 5: should have plotIndex:0",
+      );
+      assert(plotIndexResize.plot.ops.length > 0, "Step 5: should have ops");
 
-        const textsStep3 = extractTextOps(normalResize1);
-        assert(textsStep3.length > 0, "Step 3: should have text ops");
+      const textsStep5 = extractTextOps(plotIndexResize);
+      assert(textsStep5.length > 0, "Step 5: should have text ops");
 
-        // Step 5: plotIndex=0 resize — verify historical plot (plot 1) re-renders
-        const sessionId = frame1.plot.sessionId!;
-        browser.sendResizeWithPlotIndex(700, 500, 0, sessionId);
+      // Verify plot 1 (step 5) and plot 2 (step 3) have different content
+      assertNotEquals(
+        JSON.stringify(textsStep3),
+        JSON.stringify(textsStep5),
+        "Step 5 (plot 1) should differ from step 3 (plot 2)",
+      );
 
-        const plotIndexResize = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
+      // Step 7: Normal resize — THIS is the regression test.
+      // After plotIndex resize, a subsequent normal resize should
+      // re-render the current (latest) plot.
+      browser.sendResize(750, 550);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        assertEquals(plotIndexResize.resize, true, "Step 5: should have resize:true");
-        assertEquals(plotIndexResize.plotIndex, 0, "Step 5: should have plotIndex:0");
-        assert(plotIndexResize.plot.ops.length > 0, "Step 5: should have ops");
+      const normalResize2 = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
+      );
 
-        const textsStep5 = extractTextOps(plotIndexResize);
-        assert(textsStep5.length > 0, "Step 5: should have text ops");
+      assertEquals(
+        normalResize2.resize,
+        true,
+        "Step 7: should have resize:true",
+      );
+      assertEquals(
+        normalResize2.plotIndex,
+        undefined,
+        "Step 7: should NOT have plotIndex",
+      );
+      assert(normalResize2.plot.ops.length > 0, "Step 7: should have ops");
 
-        // Verify plot 1 (step 5) and plot 2 (step 3) have different content
-        assertNotEquals(
-          JSON.stringify(textsStep3),
-          JSON.stringify(textsStep5),
-          "Step 5 (plot 1) should differ from step 3 (plot 2)",
-        );
+      // Step 7 should re-render the current (latest) plot, i.e. plot(4:6),
+      // which has the same content as step 3 (also plot 2).
+      const textsStep7 = extractTextOps(normalResize2);
+      assertEquals(
+        JSON.stringify(textsStep7),
+        JSON.stringify(textsStep3),
+        "Step 7 should re-render the same plot as step 3 (both are the latest plot)",
+      );
 
-        // Step 7: Normal resize — THIS is the regression test.
-        // After plotIndex resize, a subsequent normal resize should
-        // re-render the current (latest) plot.
-        browser.sendResize(750, 550);
-
-        const normalResize2 = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
-
-        assertEquals(normalResize2.resize, true, "Step 7: should have resize:true");
-        assertEquals(normalResize2.plotIndex, undefined, "Step 7: should NOT have plotIndex");
-        assert(normalResize2.plot.ops.length > 0, "Step 7: should have ops");
-
-        // Step 7 should re-render the current (latest) plot, i.e. plot(4:6),
-        // which has the same content as step 3 (also plot 2).
-        const textsStep7 = extractTextOps(normalResize2);
-        assertEquals(
-          JSON.stringify(textsStep7),
-          JSON.stringify(textsStep3),
-          "Step 7 should re-render the same plot as step 3 (both are the latest plot)",
-        );
-
-        // Also verify step 7 differs from step 5 (which was plot 1)
-        assertNotEquals(
-          JSON.stringify(textsStep7),
-          JSON.stringify(textsStep5),
-          "Step 7 (latest plot) should differ from step 5 (historical plot)",
-        );
-      } finally {
-        r.kill();
-        try { await r.process.output(); } catch { /* ignore */ }
-      }
+      // Also verify step 7 differs from step 5 (which was plot 1)
+      assertNotEquals(
+        JSON.stringify(textsStep7),
+        JSON.stringify(textsStep5),
+        "Step 7 (latest plot) should differ from step 5 (historical plot)",
+      );
     } finally {
       browser.close();
       await delay(100);
       await server.shutdown();
       server.cleanup();
+      await arf.shutdown();
     }
   },
 });
 
 Deno.test({
   name: "E2E: normal resize not deduped when dims match pre-plotIndex state",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -143,61 +175,73 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); plot(1:3); plot(4:6); for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+      await arf.eval("plot(1:3); plot(4:6)");
+
+      // Wait for both plots
+      const initFrame = await browser.waitForType<FrameMessage>("frame", 15000);
+      await browser.waitForType<FrameMessage>("frame", 15000);
+      const sessionId = initFrame.plot.sessionId!;
+
+      // Normal resize AFTER R session is established to properly set
+      // the server's lastResizeW/H dedup state.
+      browser.sendResize(640, 480);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      const firstNormal = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
+      );
+      assertEquals(firstNormal.resize, true);
+      // lastResizeW/H is now 640x480 on the server
+
+      // plotIndex resize with DIFFERENT dimensions (700x500).
+      // This bypasses dedup and updates lastResizeW/H to 700x500.
+      // R's device dimensions are also changed to 700x500.
+      browser.sendResizeWithPlotIndex(700, 500, 0, sessionId);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      const plotIndexFrame = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
+      );
+      assertEquals(plotIndexFrame.plotIndex, 0);
+
+      // Now send a normal resize with 640x480.  The server's lastResizeW/H
+      // is 700x500 (plotIndex resize updated dedup state), so 640x480
+      // should be forwarded (different dims).
+      browser.sendResize(640, 480);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      const normalFrame = await browser.waitForMessage<FrameMessage>(
+        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
+        10000,
       );
 
-      try {
-        // Wait for both plots
-        const initFrame = await browser.waitForType<FrameMessage>("frame", 15000);
-        await browser.waitForType<FrameMessage>("frame", 15000);
-        const sessionId = initFrame.plot.sessionId!;
-
-        // Normal resize AFTER R session is established to properly set
-        // the server's lastResizeW/H dedup state.
-        browser.sendResize(640, 480);
-
-        const firstNormal = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
-        assertEquals(firstNormal.resize, true);
-        // lastResizeW/H is now 640x480 on the server
-
-        // plotIndex resize with DIFFERENT dimensions (700x500).
-        // This bypasses dedup and updates lastResizeW/H to 700x500.
-        // R's device dimensions are also changed to 700x500.
-        browser.sendResizeWithPlotIndex(700, 500, 0, sessionId);
-
-        const plotIndexFrame = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
-        assertEquals(plotIndexFrame.plotIndex, 0);
-
-        // Now send a normal resize with 640x480.  The server's lastResizeW/H
-        // is 700x500 (plotIndex resize updated dedup state), so 640x480
-        // should be forwarded (different dims).
-        browser.sendResize(640, 480);
-
-        const normalFrame = await browser.waitForMessage<FrameMessage>(
-          (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
-        );
-
-        assertEquals(normalFrame.resize, true, "Normal resize should not be deduped");
-        assertEquals(normalFrame.plotIndex, undefined, "Should be a normal resize");
-        assert(normalFrame.plot.ops.length > 0, "Should have ops");
-      } finally {
-        r.kill();
-        try { await r.process.output(); } catch { /* ignore */ }
-      }
+      assertEquals(
+        normalFrame.resize,
+        true,
+        "Normal resize should not be deduped",
+      );
+      assertEquals(
+        normalFrame.plotIndex,
+        undefined,
+        "Should be a normal resize",
+      );
+      assert(normalFrame.plot.ops.length > 0, "Should have ops");
     } finally {
       browser.close();
       await delay(100);
       await server.shutdown();
       server.cleanup();
+      await arf.shutdown();
     }
   },
 });

--- a/tests/plotindex_regression_test.ts
+++ b/tests/plotindex_regression_test.ts
@@ -38,7 +38,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -48,10 +48,10 @@ Deno.test({
       await arf.eval("plot(1:3); plot(4:6)");
 
       // Step 1-2: Wait for both plots
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame1.plot.ops.length > 0, "First frame should have ops");
 
-      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame2.plot.ops.length > 0, "Second frame should have ops");
 
       // Step 3: Normal resize — verify latest plot (plot 2) re-renders
@@ -61,7 +61,7 @@ Deno.test({
 
       const normalResize1 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
 
       assertEquals(
@@ -87,7 +87,7 @@ Deno.test({
 
       const plotIndexResize = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
 
       assertEquals(
@@ -121,7 +121,7 @@ Deno.test({
 
       const normalResize2 = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
 
       assertEquals(
@@ -173,7 +173,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -183,8 +183,8 @@ Deno.test({
       await arf.eval("plot(1:3); plot(4:6)");
 
       // Wait for both plots
-      const initFrame = await browser.waitForType<FrameMessage>("frame", 15000);
-      await browser.waitForType<FrameMessage>("frame", 15000);
+      const initFrame = await browser.waitForType<FrameMessage>("frame", 8000);
+      await browser.waitForType<FrameMessage>("frame", 8000);
       const sessionId = initFrame.plot.sessionId!;
 
       // Normal resize AFTER R session is established to properly set
@@ -195,7 +195,7 @@ Deno.test({
 
       const firstNormal = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
       assertEquals(firstNormal.resize, true);
       // lastResizeW/H is now 640x480 on the server
@@ -209,7 +209,7 @@ Deno.test({
 
       const plotIndexFrame = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
       assertEquals(plotIndexFrame.plotIndex, 0);
 
@@ -222,7 +222,7 @@ Deno.test({
 
       const normalFrame = await browser.waitForMessage<FrameMessage>(
         (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        10000,
+        6000,
       );
 
       assertEquals(

--- a/tests/plotindex_regression_test.ts
+++ b/tests/plotindex_regression_test.ts
@@ -15,14 +15,15 @@
  */
 
 import { assert, assertEquals, assertNotEquals } from "@std/assert";
-import { delay } from "@std/async";
-import { TestServer } from "../server/tests/helpers/server.ts";
-import type { FrameMessage } from "../server/tests/helpers/types.ts";
-import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { pollResize } from "./helpers/arf_poll.ts";
+import {
+  createTwoBasePlots,
+  sendPlotIndexResizeAndPoll,
+  sendResizeAndPoll,
+  startArfBrowserTest,
+  waitForResizeFrame,
+} from "./helpers/arf_e2e.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
-import { toRSocketAddress } from "./helpers/r_process.ts";
+import { checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
@@ -33,39 +34,15 @@ Deno.test({
   ignore: skip,
   async fn() {
     testLog("test start");
-    const server = new TestServer({ tcp: true });
-    const browser = new AutoMetricsBrowserClient();
-    const arf = new ArfSession();
+    const ctx = await startArfBrowserTest();
 
     try {
-      await server.start();
-      await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
-      await arf.start();
-      const socketAddr = toRSocketAddress(server.socketPath);
-      await arf.eval(
-        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
-      );
-      await arf.eval("plot(1:3); plot(4:6)");
-
-      // Step 1-2: Wait for both plots
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
-      assert(frame1.plot.ops.length > 0, "First frame should have ops");
-
-      const frame2 = await browser.waitForType<FrameMessage>("frame", 8000);
-      assert(frame2.plot.ops.length > 0, "Second frame should have ops");
+      const [frame1] = await createTwoBasePlots(ctx);
 
       // Step 3: Normal resize — verify latest plot (plot 2) re-renders
-      browser.sendResize(640, 480);
-      await browser.sendPing(3000);
-      await pollResize(arf, 40);
+      await sendResizeAndPoll(ctx, 640, 480);
 
-      const normalResize1 = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        6000,
-      );
+      const normalResize1 = await waitForResizeFrame(ctx.browser);
 
       assertEquals(
         normalResize1.resize,
@@ -84,14 +61,9 @@ Deno.test({
 
       // Step 5: plotIndex=0 resize — verify historical plot (plot 1) re-renders
       const sessionId = frame1.plot.sessionId!;
-      browser.sendResizeWithPlotIndex(700, 500, 0, sessionId);
-      await browser.sendPing(3000);
-      await pollResize(arf, 40);
+      await sendPlotIndexResizeAndPoll(ctx, 700, 500, 0, sessionId);
 
-      const plotIndexResize = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        6000,
-      );
+      const plotIndexResize = await waitForResizeFrame(ctx.browser);
 
       assertEquals(
         plotIndexResize.resize,
@@ -118,14 +90,9 @@ Deno.test({
       // Step 7: Normal resize — THIS is the regression test.
       // After plotIndex resize, a subsequent normal resize should
       // re-render the current (latest) plot.
-      browser.sendResize(750, 550);
-      await browser.sendPing(3000);
-      await pollResize(arf, 40);
+      await sendResizeAndPoll(ctx, 750, 550);
 
-      const normalResize2 = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        6000,
-      );
+      const normalResize2 = await waitForResizeFrame(ctx.browser);
 
       assertEquals(
         normalResize2.resize,
@@ -155,11 +122,7 @@ Deno.test({
         "Step 7 (latest plot) should differ from step 5 (historical plot)",
       );
     } finally {
-      browser.close();
-      await delay(100);
-      await server.shutdown();
-      server.cleanup();
-      await arf.shutdown();
+      await ctx.close();
     }
   },
 });
@@ -169,65 +132,34 @@ Deno.test({
   ignore: skip,
   async fn() {
     testLog("test start");
-    const server = new TestServer({ tcp: true });
-    const browser = new AutoMetricsBrowserClient();
-    const arf = new ArfSession();
+    const ctx = await startArfBrowserTest();
 
     try {
-      await server.start();
-      await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
-      await arf.start();
-      const socketAddr = toRSocketAddress(server.socketPath);
-      await arf.eval(
-        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
-      );
-      await arf.eval("plot(1:3); plot(4:6)");
-
-      // Wait for both plots
-      const initFrame = await browser.waitForType<FrameMessage>("frame", 8000);
-      await browser.waitForType<FrameMessage>("frame", 8000);
+      const [initFrame] = await createTwoBasePlots(ctx);
       const sessionId = initFrame.plot.sessionId!;
 
       // Normal resize AFTER R session is established to properly set
       // the server's lastResizeW/H dedup state.
-      browser.sendResize(640, 480);
-      await browser.sendPing(3000);
-      await pollResize(arf, 40);
+      await sendResizeAndPoll(ctx, 640, 480);
 
-      const firstNormal = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        6000,
-      );
+      const firstNormal = await waitForResizeFrame(ctx.browser);
       assertEquals(firstNormal.resize, true);
       // lastResizeW/H is now 640x480 on the server
 
       // plotIndex resize with DIFFERENT dimensions (700x500).
       // This bypasses dedup and updates lastResizeW/H to 700x500.
       // R's device dimensions are also changed to 700x500.
-      browser.sendResizeWithPlotIndex(700, 500, 0, sessionId);
-      await browser.sendPing(3000);
-      await pollResize(arf, 40);
+      await sendPlotIndexResizeAndPoll(ctx, 700, 500, 0, sessionId);
 
-      const plotIndexFrame = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        6000,
-      );
+      const plotIndexFrame = await waitForResizeFrame(ctx.browser);
       assertEquals(plotIndexFrame.plotIndex, 0);
 
       // Now send a normal resize with 640x480.  The server's lastResizeW/H
       // is 700x500 (plotIndex resize updated dedup state), so 640x480
       // should be forwarded (different dims).
-      browser.sendResize(640, 480);
-      await browser.sendPing(3000);
-      await pollResize(arf, 40);
+      await sendResizeAndPoll(ctx, 640, 480);
 
-      const normalFrame = await browser.waitForMessage<FrameMessage>(
-        (msg) => msg.type === "frame" && (msg as FrameMessage).resize === true,
-        6000,
-      );
+      const normalFrame = await waitForResizeFrame(ctx.browser);
 
       assertEquals(
         normalFrame.resize,
@@ -241,11 +173,7 @@ Deno.test({
       );
       assert(normalFrame.plot.ops.length > 0, "Should have ops");
     } finally {
-      browser.close();
-      await delay(100);
-      await server.shutdown();
-      server.cleanup();
-      await arf.shutdown();
+      await ctx.close();
     }
   },
 });

--- a/tests/plotindex_session_test.ts
+++ b/tests/plotindex_session_test.ts
@@ -37,9 +37,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       const socketAddr = toRSocketAddress(server.socketPath);
 
       // --- Session 1: generate plot 1 (plot(1:3)) ---

--- a/tests/plotindex_session_test.ts
+++ b/tests/plotindex_session_test.ts
@@ -18,16 +18,19 @@ import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
   name: "E2E: plotIndex resize after R restart does not corrupt history",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf2 = new ArfSession();
 
     try {
       await server.start();
@@ -35,85 +38,88 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
+      const socketAddr = toRSocketAddress(server.socketPath);
+
       // --- Session 1: generate plot 1 (plot(1:3)) ---
-      const r1 = startR(
-        'jgd(width=8, height=6, dpi=96); plot(1:3); for (i in 1:100) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      const arf1 = new ArfSession();
+      await arf1.start();
+      await arf1.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
       );
+      await arf1.eval("plot(1:3)");
 
       const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
       assert(frame1.plot.ops.length > 0, "Session 1 frame should have ops");
       const texts1 = extractTextOps(frame1);
       const session1Id = frame1.plot.sessionId;
 
-      // Kill session 1 and wait for disconnect
-      r1.kill();
-      try { await r1.process.output(); } catch { /* ignore */ }
+      // Shut down session 1 and wait for disconnect
+      await arf1.shutdown();
       await delay(500);
 
       // --- Session 2: generate plot 2 (plot(4:6)) ---
-      const r2 = startR(
-        'jgd(width=8, height=6, dpi=96); plot(4:6); for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf2.start();
+      await arf2.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+      await arf2.eval("plot(4:6)");
+
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      assert(frame2.plot.ops.length > 0, "Session 2 frame should have ops");
+      const texts2 = extractTextOps(frame2);
+      const session2Id = frame2.plot.sessionId;
+
+      // Verify the sessions are different
+      assertNotEquals(
+        session1Id,
+        session2Id,
+        "R sessions should have different IDs",
+      );
+      assertNotEquals(
+        JSON.stringify(texts1),
+        JSON.stringify(texts2),
+        "Plot 1 and plot 2 should have different content",
       );
 
-      try {
-        const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
-        assert(frame2.plot.ops.length > 0, "Session 2 frame should have ops");
-        const texts2 = extractTextOps(frame2);
-        const session2Id = frame2.plot.sessionId;
+      // --- Send plotIndex=0 resize (targeting plot 1 from dead session 1) ---
+      // Include session1Id so the server routes to the correct (dead) session.
+      browser.sendResizeWithPlotIndex(640, 480, 0, session1Id);
 
-        // Verify the sessions are different
-        assertNotEquals(
-          session1Id,
-          session2Id,
-          "R sessions should have different IDs",
-        );
-        assertNotEquals(
-          JSON.stringify(texts1),
-          JSON.stringify(texts2),
-          "Plot 1 and plot 2 should have different content",
-        );
+      // The server routes the plotIndex resize to session 1 only (via
+      // sessionId).  Since session 1 is dead, the resize is silently
+      // dropped — no frame should arrive.  This prevents session confusion
+      // where session 2 would render its own plot at new dimensions and
+      // the server would tag it as plotIndex=0, corrupting history.
 
-        // --- Send plotIndex=0 resize (targeting plot 1 from dead session 1) ---
-        // Include session1Id so the server routes to the correct (dead) session.
-        browser.sendResizeWithPlotIndex(640, 480, 0, session1Id);
+      // Send a ping sentinel: any server-side message queued before the
+      // pong will arrive first.  Race the pong against a frame waiter —
+      // if the pong wins, the server correctly dropped the plotIndex resize.
+      // AbortController cancels the losing waiter so it doesn't consume
+      // later messages.
+      const ac = new AbortController();
+      const sentinel = Symbol("pong");
+      const resizeFrame = await Promise.race([
+        browser.waitForMessage<FrameMessage>(
+          (msg) =>
+            msg.type === "frame" && (msg as FrameMessage).resize === true,
+          10000,
+          ac.signal,
+        ).catch(() => null),
+        browser.sendPing(5000).then(() => {
+          ac.abort();
+          return sentinel;
+        }),
+      ]);
 
-        // The server routes the plotIndex resize to session 1 only (via
-        // sessionId).  Since session 1 is dead, the resize is silently
-        // dropped — no frame should arrive.  This prevents session confusion
-        // where session 2 would render its own plot at new dimensions and
-        // the server would tag it as plotIndex=0, corrupting history.
-
-        // Send a ping sentinel: any server-side message queued before the
-        // pong will arrive first.  Race the pong against a frame waiter —
-        // if the pong wins, the server correctly dropped the plotIndex resize.
-        // AbortController cancels the losing waiter so it doesn't consume
-        // later messages.
-        const ac = new AbortController();
-        const sentinel = Symbol("pong");
-        const resizeFrame = await Promise.race([
-          browser.waitForMessage<FrameMessage>(
-            (msg) =>
-              msg.type === "frame" && (msg as FrameMessage).resize === true,
-            10000,
-            ac.signal,
-          ).catch(() => null),
-          browser.sendPing(5000).then(() => { ac.abort(); return sentinel; }),
-        ]);
-
-        // No frame should arrive — session 1 is dead and cannot re-render.
-        // The server should drop the plotIndex resize entirely.
-        assertEquals(
-          resizeFrame,
-          sentinel,
-          "No resize frame should arrive — session 1 is dead and cannot re-render plot 1",
-        );
-      } finally {
-        r2.kill();
-        try { await r2.process.output(); } catch { /* ignore */ }
-      }
+      // No frame should arrive — session 1 is dead and cannot re-render.
+      // The server should drop the plotIndex resize entirely.
+      assertEquals(
+        resizeFrame,
+        sentinel,
+        "No resize frame should arrive — session 1 is dead and cannot re-render plot 1",
+      );
     } finally {
+      await arf2.shutdown();
       browser.close();
       await delay(100);
       await server.shutdown();

--- a/tests/plotindex_session_test.ts
+++ b/tests/plotindex_session_test.ts
@@ -111,12 +111,11 @@ Deno.test({
       const sentinel = Symbol("pong");
       const resizeFrame = await Promise.race([
         browser.waitForMessage<FrameMessage>(
-          (msg) =>
-            msg.type === "frame" && (msg as FrameMessage).resize === true,
+          (msg) => msg.type === "frame",
           6000,
           ac.signal,
         ).catch(() => null),
-        browser.sendPing(6000).then(() => {
+        browser.sendPing(3000).then(() => {
           ac.abort();
           return sentinel;
         }),

--- a/tests/plotindex_session_test.ts
+++ b/tests/plotindex_session_test.ts
@@ -19,10 +19,10 @@ import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name: "E2E: plotIndex resize after R restart does not corrupt history",

--- a/tests/plotindex_session_test.ts
+++ b/tests/plotindex_session_test.ts
@@ -42,19 +42,22 @@ Deno.test({
 
       // --- Session 1: generate plot 1 (plot(1:3)) ---
       const arf1 = new ArfSession();
-      await arf1.start();
-      await arf1.eval(
-        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
-      );
-      await arf1.eval("plot(1:3)");
+      let texts1: string[] = [];
+      let session1Id = "";
+      try {
+        await arf1.start();
+        await arf1.eval(
+          `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+        );
+        await arf1.eval("plot(1:3)");
 
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
-      assert(frame1.plot.ops.length > 0, "Session 1 frame should have ops");
-      const texts1 = extractTextOps(frame1);
-      const session1Id = frame1.plot.sessionId;
-
-      // Shut down session 1 and wait for disconnect
-      await arf1.shutdown();
+        const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
+        assert(frame1.plot.ops.length > 0, "Session 1 frame should have ops");
+        texts1 = extractTextOps(frame1);
+        session1Id = frame1.plot.sessionId || "";
+      } finally {
+        await arf1.shutdown();
+      }
       await delay(500);
 
       // --- Session 2: generate plot 2 (plot(4:6)) ---
@@ -68,6 +71,7 @@ Deno.test({
       assert(frame2.plot.ops.length > 0, "Session 2 frame should have ops");
       const texts2 = extractTextOps(frame2);
       const session2Id = frame2.plot.sessionId;
+      assert(session1Id, "Session 1 must provide a sessionId");
 
       // Verify the sessions are different
       assertNotEquals(

--- a/tests/plotindex_session_test.ts
+++ b/tests/plotindex_session_test.ts
@@ -20,6 +20,7 @@ import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { extractTextOps } from "./helpers/plot_ops.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
@@ -28,6 +29,7 @@ Deno.test({
   name: "E2E: plotIndex resize after R restart does not corrupt history",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf2 = new ArfSession();

--- a/tests/plotindex_session_test.ts
+++ b/tests/plotindex_session_test.ts
@@ -105,7 +105,7 @@ Deno.test({
           6000,
           ac.signal,
         ).catch(() => null),
-        browser.sendPing(2000).then(() => {
+        browser.sendPing(6000).then(() => {
           ac.abort();
           return sentinel;
         }),

--- a/tests/plotindex_session_test.ts
+++ b/tests/plotindex_session_test.ts
@@ -90,7 +90,11 @@ Deno.test({
       // --- Send plotIndex=0 resize (targeting plot 1 from dead session 1) ---
       // Include session1Id so the server routes to the correct (dead) session.
       browser.sendResizeWithPlotIndex(640, 480, 0, session1Id);
-      await delay(100);
+      // Ping ordering probe before polling arf2: if a buggy server misroutes
+      // the resize to session 2, it lands in arf2's queue before the poll
+      // runs, so the poll deterministically observes (and would produce) any
+      // misrouted frame instead of racing the delivery.
+      await browser.sendPing(3000);
       await arf2.eval(
         "for (i in 1:40) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }",
         60_000,

--- a/tests/plotindex_session_test.ts
+++ b/tests/plotindex_session_test.ts
@@ -36,7 +36,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       const socketAddr = toRSocketAddress(server.socketPath);
 
@@ -48,7 +48,7 @@ Deno.test({
       );
       await arf1.eval("plot(1:3)");
 
-      const frame1 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame1 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame1.plot.ops.length > 0, "Session 1 frame should have ops");
       const texts1 = extractTextOps(frame1);
       const session1Id = frame1.plot.sessionId;
@@ -64,7 +64,7 @@ Deno.test({
       );
       await arf2.eval("plot(4:6)");
 
-      const frame2 = await browser.waitForType<FrameMessage>("frame", 15000);
+      const frame2 = await browser.waitForType<FrameMessage>("frame", 8000);
       assert(frame2.plot.ops.length > 0, "Session 2 frame should have ops");
       const texts2 = extractTextOps(frame2);
       const session2Id = frame2.plot.sessionId;
@@ -102,10 +102,10 @@ Deno.test({
         browser.waitForMessage<FrameMessage>(
           (msg) =>
             msg.type === "frame" && (msg as FrameMessage).resize === true,
-          10000,
+          6000,
           ac.signal,
         ).catch(() => null),
-        browser.sendPing(5000).then(() => {
+        browser.sendPing(2000).then(() => {
           ac.abort();
           return sentinel;
         }),

--- a/tests/plotindex_session_test.ts
+++ b/tests/plotindex_session_test.ts
@@ -90,6 +90,11 @@ Deno.test({
       // --- Send plotIndex=0 resize (targeting plot 1 from dead session 1) ---
       // Include session1Id so the server routes to the correct (dead) session.
       browser.sendResizeWithPlotIndex(640, 480, 0, session1Id);
+      await delay(100);
+      await arf2.eval(
+        "for (i in 1:40) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }",
+        60_000,
+      );
 
       // The server routes the plotIndex resize to session 1 only (via
       // sessionId).  Since session 1 is dead, the resize is silently

--- a/tests/resize_newpage_bug_test.ts
+++ b/tests/resize_newpage_bug_test.ts
@@ -22,6 +22,7 @@ import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
+import { testLog } from "./helpers/test_log.ts";
 
 const arfTestAvailable = await checkArfTestAvailable();
 const skip = !arfTestAvailable;
@@ -30,6 +31,7 @@ Deno.test({
   name: "E2E: resize replay frame must have resize:true, not newPage:true",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();
@@ -97,6 +99,7 @@ Deno.test({
   name: "E2E: two resizes do not create extra plot entries",
   ignore: skip,
   async fn() {
+    testLog("test start");
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
     const arf = new ArfSession();

--- a/tests/resize_newpage_bug_test.ts
+++ b/tests/resize_newpage_bug_test.ts
@@ -20,16 +20,19 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { checkRAvailable, startR } from "./helpers/r_process.ts";
+import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const rAvailable = await checkRAvailable();
+const arfAvailable = await checkArfAvailable();
+const skip = !arfAvailable;
 
 Deno.test({
   name: "E2E: resize replay frame must have resize:true, not newPage:true",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -37,68 +40,66 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
-      // Single plot + polling loop for resize processing
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); plot(1:5); for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+      await arf.eval("plot(1:5)");
+
+      // Wait for the initial plot frame
+      const plotFrame = await browser.waitForType<FrameMessage>(
+        "frame",
+        15000,
+      );
+      assert(plotFrame.plot.ops.length > 0, "Initial plot should have ops");
+
+      // Send a resize with different dimensions
+      browser.sendResize(640, 480);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      // Wait for ANY frame (not filtering by resize:true) to see what R
+      // actually sends after the resize.
+      const resizeFrame = await browser.waitForType<FrameMessage>(
+        "frame",
+        10000,
       );
 
-      try {
-        // Wait for the initial plot frame
-        const plotFrame = await browser.waitForType<FrameMessage>(
-          "frame",
-          15000,
-        );
-        assert(plotFrame.plot.ops.length > 0, "Initial plot should have ops");
+      // The resize replay frame MUST be tagged with resize:true so the
+      // browser calls replaceLatest instead of addPlot.
+      assertEquals(
+        resizeFrame.resize,
+        true,
+        "Resize replay frame must have resize:true — " +
+          `got resize=${resizeFrame.resize}, newPage=${resizeFrame.newPage}`,
+      );
 
-        // Send a resize with different dimensions
-        browser.sendResize(640, 480);
-
-        // Wait for ANY frame (not filtering by resize:true) to see what R
-        // actually sends after the resize.
-        const resizeFrame = await browser.waitForType<FrameMessage>(
-          "frame",
-          10000,
-        );
-
-        // The resize replay frame MUST be tagged with resize:true so the
-        // browser calls replaceLatest instead of addPlot.
-        assertEquals(
-          resizeFrame.resize,
-          true,
-          "Resize replay frame must have resize:true — " +
-            `got resize=${resizeFrame.resize}, newPage=${resizeFrame.newPage}`,
-        );
-
-        // The frame must NOT have newPage:true.  If it does, the C code
-        // is incorrectly setting new_page during GEplayDisplayList replay.
-        assertEquals(
-          resizeFrame.newPage,
-          undefined,
-          "Resize replay frame must not have newPage — cb_newPage should " +
-            "not set new_page flag during replaying",
-        );
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
-      }
+      // The frame must NOT have newPage:true.  If it does, the C code
+      // is incorrectly setting new_page during GEplayDisplayList replay.
+      assertEquals(
+        resizeFrame.newPage,
+        undefined,
+        "Resize replay frame must not have newPage — cb_newPage should " +
+          "not set new_page flag during replaying",
+      );
     } finally {
       browser.close();
       await delay(100);
       await server.shutdown();
       server.cleanup();
+      await arf.shutdown();
     }
   },
 });
 
 Deno.test({
   name: "E2E: two resizes do not create extra plot entries",
-  ignore: !rAvailable,
+  ignore: skip,
   async fn() {
     const server = new TestServer({ tcp: true });
     const browser = new AutoMetricsBrowserClient();
+    const arf = new ArfSession();
 
     try {
       await server.start();
@@ -106,66 +107,65 @@ Deno.test({
       browser.sendResize(800, 600);
       await delay(200);
 
-      // Two plots + polling loop
-      const r = startR(
-        'jgd(width=8, height=6, dpi=96); plot(1:3); plot(4:6); for (i in 1:200) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.05) }',
-        server.socketPath,
+      await arf.start();
+      const socketAddr = toRSocketAddress(server.socketPath);
+      await arf.eval(
+        `options(jgd.socket = "${socketAddr}"); library(jgd); jgd(width=8, height=6, dpi=96)`,
+      );
+      await arf.eval("plot(1:3); plot(4:6)");
+
+      // Wait for both plot frames
+      await browser.waitForType<FrameMessage>("frame", 15000);
+      await browser.waitForType<FrameMessage>("frame", 15000);
+
+      // Count total frames received: should be exactly 2 so far.
+      // Now send resize — should produce exactly 1 more frame with resize:true.
+      browser.sendResize(640, 480);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+
+      const frame3 = await browser.waitForType<FrameMessage>(
+        "frame",
+        10000,
       );
 
-      try {
-        // Wait for both plot frames
-        await browser.waitForType<FrameMessage>("frame", 15000);
-        await browser.waitForType<FrameMessage>("frame", 15000);
+      assertEquals(
+        frame3.resize,
+        true,
+        "First resize frame must be tagged resize:true",
+      );
+      assertEquals(
+        frame3.newPage,
+        undefined,
+        "First resize frame must not have newPage",
+      );
 
-        // Count total frames received: should be exactly 2 so far.
-        // Now send resize — should produce exactly 1 more frame with resize:true.
-        browser.sendResize(640, 480);
+      // Send another resize
+      browser.sendResize(700, 500);
+      await delay(100); // allow WS message to propagate to server
+      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
 
-        const frame3 = await browser.waitForType<FrameMessage>(
-          "frame",
-          10000,
-        );
+      const frame4 = await browser.waitForType<FrameMessage>(
+        "frame",
+        10000,
+      );
 
-        assertEquals(
-          frame3.resize,
-          true,
-          "First resize frame must be tagged resize:true",
-        );
-        assertEquals(
-          frame3.newPage,
-          undefined,
-          "First resize frame must not have newPage",
-        );
-
-        // Send another resize
-        browser.sendResize(700, 500);
-
-        const frame4 = await browser.waitForType<FrameMessage>(
-          "frame",
-          10000,
-        );
-
-        assertEquals(
-          frame4.resize,
-          true,
-          "Second resize frame must also be tagged resize:true",
-        );
-        assertEquals(
-          frame4.newPage,
-          undefined,
-          "Second resize frame must not have newPage",
-        );
-      } finally {
-        r.kill();
-        try {
-          await r.process.output();
-        } catch { /* ignore */ }
-      }
+      assertEquals(
+        frame4.resize,
+        true,
+        "Second resize frame must also be tagged resize:true",
+      );
+      assertEquals(
+        frame4.newPage,
+        undefined,
+        "Second resize frame must not have newPage",
+      );
     } finally {
       browser.close();
       await delay(100);
       await server.shutdown();
       server.cleanup();
+      await arf.shutdown();
     }
   },
 });

--- a/tests/resize_newpage_bug_test.ts
+++ b/tests/resize_newpage_bug_test.ts
@@ -40,9 +40,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await arf.eval(
@@ -108,9 +105,6 @@ Deno.test({
     try {
       await server.start();
       await browser.connect(server.wsUrl);
-      browser.sendResize(800, 600);
-      await delay(100);
-
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
       await arf.eval(

--- a/tests/resize_newpage_bug_test.ts
+++ b/tests/resize_newpage_bug_test.ts
@@ -20,11 +20,11 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
-import { ArfSession, checkArfAvailable } from "./helpers/arf_session.ts";
+import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 
-const arfAvailable = await checkArfAvailable();
-const skip = !arfAvailable;
+const arfTestAvailable = await checkArfTestAvailable();
+const skip = !arfTestAvailable;
 
 Deno.test({
   name: "E2E: resize replay frame must have resize:true, not newPage:true",

--- a/tests/resize_newpage_bug_test.ts
+++ b/tests/resize_newpage_bug_test.ts
@@ -20,6 +20,7 @@ import { delay } from "@std/async";
 import { TestServer } from "../server/tests/helpers/server.ts";
 import type { FrameMessage } from "../server/tests/helpers/types.ts";
 import { AutoMetricsBrowserClient } from "./helpers/auto_metrics_client.ts";
+import { pollResize } from "./helpers/arf_poll.ts";
 import { ArfSession, checkArfTestAvailable } from "./helpers/arf_session.ts";
 import { toRSocketAddress } from "./helpers/r_process.ts";
 import { testLog } from "./helpers/test_log.ts";
@@ -58,8 +59,8 @@ Deno.test({
 
       // Send a resize with different dimensions
       browser.sendResize(640, 480);
-      await delay(100); // allow WS message to propagate to server
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       // Wait for ANY frame (not filtering by resize:true) to see what R
       // actually sends after the resize.
@@ -124,8 +125,8 @@ Deno.test({
       // Count total frames received: should be exactly 2 so far.
       // Now send resize — should produce exactly 1 more frame with resize:true.
       browser.sendResize(640, 480);
-      await delay(100); // allow WS message to propagate to server
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const frame3 = await browser.waitForType<FrameMessage>(
         "frame",
@@ -145,8 +146,8 @@ Deno.test({
 
       // Send another resize
       browser.sendResize(700, 500);
-      await delay(100); // allow WS message to propagate to server
-      await arf.eval(".Call(jgd:::C_jgd_poll_resize)");
+      await browser.sendPing(3000);
+      await pollResize(arf, 40);
 
       const frame4 = await browser.waitForType<FrameMessage>(
         "frame",

--- a/tests/resize_newpage_bug_test.ts
+++ b/tests/resize_newpage_bug_test.ts
@@ -38,7 +38,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -50,7 +50,7 @@ Deno.test({
       // Wait for the initial plot frame
       const plotFrame = await browser.waitForType<FrameMessage>(
         "frame",
-        15000,
+        8000,
       );
       assert(plotFrame.plot.ops.length > 0, "Initial plot should have ops");
 
@@ -63,7 +63,7 @@ Deno.test({
       // actually sends after the resize.
       const resizeFrame = await browser.waitForType<FrameMessage>(
         "frame",
-        10000,
+        6000,
       );
 
       // The resize replay frame MUST be tagged with resize:true so the
@@ -105,7 +105,7 @@ Deno.test({
       await server.start();
       await browser.connect(server.wsUrl);
       browser.sendResize(800, 600);
-      await delay(200);
+      await delay(100);
 
       await arf.start();
       const socketAddr = toRSocketAddress(server.socketPath);
@@ -115,8 +115,8 @@ Deno.test({
       await arf.eval("plot(1:3); plot(4:6)");
 
       // Wait for both plot frames
-      await browser.waitForType<FrameMessage>("frame", 15000);
-      await browser.waitForType<FrameMessage>("frame", 15000);
+      await browser.waitForType<FrameMessage>("frame", 8000);
+      await browser.waitForType<FrameMessage>("frame", 8000);
 
       // Count total frames received: should be exactly 2 so far.
       // Now send resize — should produce exactly 1 more frame with resize:true.
@@ -126,7 +126,7 @@ Deno.test({
 
       const frame3 = await browser.waitForType<FrameMessage>(
         "frame",
-        10000,
+        6000,
       );
 
       assertEquals(
@@ -147,7 +147,7 @@ Deno.test({
 
       const frame4 = await browser.waitForType<FrameMessage>(
         "frame",
-        10000,
+        6000,
       );
 
       assertEquals(


### PR DESCRIPTION
## Why
The previous E2E suite drove R through `runR`/`startR` (one-shot or spawn-and-pipe Rscript helpers). That batch-style harness made browser↔R round-trip flows hard to express: each step has to know its position in a pre-baked Rscript, and resize/history regressions ended up depending on fixed sleeps to align browser and R.

This PR moves the E2E tests to an `arf ipc`-driven session model so a single test can explicitly interleave:

1. an R-side draw or `library(jgd); jgd(...)` call,
2. a browser action (resize, plotIndex resize, navigation),
3. an R-side `.Call(jgd:::C_jgd_poll_resize)` / replay step,
4. an assertion against the WebSocket frame or canvas.

It also adds dedicated regression coverage for historical-plot resize and a few previously-flaky scenarios that the new harness can finally express cleanly.

## What changed

### Harness
- **`tests/helpers/arf_session.ts`** — new `ArfSession` class wrapping `arf headless` + `arf ipc eval/shutdown` with explicit startup, eval, and shutdown lifecycle. Failures during startup (timeout, invalid ready JSON, spawn errors) tear the child down rather than leak it, and shutdown still kills the headless process even when `arf ipc shutdown` cannot be spawned.
- **`tests/helpers/arf_e2e.ts`** — shared `startArfBrowserTest` / `startArfPageTest` setup contexts, `sendResizeAndPoll` / `sendPlotIndexResizeAndPoll` helpers, and `assertNoExtraFrameBeforePong` for negative assertions. Cleanup runs even when setup fails partway through.
- **`tests/helpers/arf_poll.ts`** — small `pollResize(arf, iterations)` helper so tests don't duplicate the same `for (i in 1:N) { .Call(jgd:::C_jgd_poll_resize); Sys.sleep(0.005) }` loop.
- **`tests/helpers/r_process.ts`** — `runR`/`startR` removed. Only the socket-address helper and the R-availability check remain.

### Deterministic resize synchronization
- Resize tests no longer rely on `await delay(100)` before `pollResize`. The `BrowserClient.sendPing(timeoutMs)` ordering probe is used instead: because the test WebSocket is FIFO and the server is single-threaded, awaiting the pong guarantees the resize message has already been enqueued before R polls. Negative assertions use `Promise.race(frame, sendPing)` so a misrouted frame is observed deterministically rather than racing the pong.

### New regression coverage
- `plotindex_history_resize_test.ts` — protocol + full-stack historical resize coverage for multi-step plots (group ops, frame extensions, base graphics + lines).
- `plotindex_abline_after_ggplot2_test.ts` — abline must survive a plotIndex resize when the next plot is a grid-based ggplot2 (the case where `grid.newpage()` skips `dev.hold()` and an incomplete snapshot would be stored).
- `arf_session_eval_error_test.ts` — startup/shutdown failure modes, `eval` error propagation (default throw vs. `throwOnRError: false`), and double-/concurrent-start rejection.
- Various existing files gained interleaved browser-action steps that were previously infeasible under the batch harness (gc replay, ggplot2 newpage, plotindex regressions, resize-during-draw, etc.).

### CI / docs / DX
- `.github/workflows/e2e-test.yaml` installs `arf` v0.3.3 from its GitHub release with a per-OS sha256 check (Linux tar.xz, Windows zip).
- `tests/README.md` documents prerequisites (R + jgd, Deno v2, arf v0.3.0+) and how to run the suite.
- `tests/deno.json` adds a `test:fail-fast` task for local iteration; the default `test` task is unchanged.

## Non-goals
- No protocol or spec changes.
- No production renderer or device behavior changes — this is purely a test-harness migration plus the regression tests that the new harness enables.
- The legacy interactive-R harness path (`newpage_interactive_r_test.ts`) is kept as-is; it already worked over stdin and the ARF model would not improve it.

## Validation
- `cd tests && ASTRAL_BIN_ARGS='--no-sandbox --disable-dev-shm-usage' deno task test` passes locally on this branch. Tests that need a missing prerequisite (`arf`, R, jgd, ggplot2) skip via `checkArfTestAvailable` / `checkGgplot2Available` rather than hard-fail.
- Targeted re-runs after timing/race-window edits: plotindex / session / extra-frame / history-resize regression tests, ggplot2 newpage + plotIndex replay, fullstack duplicate + resize-during-draw scenarios.

## Reviewer focus
- `tests/helpers/arf_session.ts` — process lifecycle and cleanup paths on startup/shutdown failure.
- `tests/helpers/arf_e2e.ts` — setup-failure cleanup and the shared resize-and-poll patterns.
- Resize/poll sites in individual tests — confirm `sendPing` ordering is used (or intentionally not used) for each resize → R poll handoff.
- `.github/workflows/e2e-test.yaml` — arf install/extract logic, especially the Windows zip strip-components path.
