### PR TITLE
fix(vscode-ext): prevent stale JGD_SOCKET after window reload

### DIFF
--- a/vscode-ext/src/extension.ts
+++ b/vscode-ext/src/extension.ts
@@ -11,6 +11,8 @@ let statusBarItem: vscode.StatusBarItem;
 export function activate(context: vscode.ExtensionContext) {
     console.log('jgd: extension activating');
 
+    context.environmentVariableCollection.persistent = false;
+
     history = new PlotHistory(
         vscode.workspace.getConfiguration('jgd').get('historyLimit', 50)
     );


### PR DESCRIPTION
Closes #63

- Set `environmentVariableCollection.persistent = false` so VS Code does not replay an outdated socket path into new terminals after a reload
- Terminals opened before activation now fall through to the discovery file, which always has the correct path