### PR TITLE
ci: fix Deno v2.x E2E regressions (pin + setTimeout types)

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -52,7 +52,12 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          # Pinned to 2.7.14: newer v2.x releases broke the native-transport
+          # E2E tests. A node:net server binding a named pipe (Windows) or
+          # unix socket now raises NotCapable despite --allow-read/--allow-write,
+          # demanding --allow-all. Same area as denoland/deno#33366 (the bug
+          # #52 pinned around). Revisit once resolved upstream.
+          deno-version: v2.7.14
 
       - name: Install arf
         run: |

--- a/.github/workflows/server-test.yaml
+++ b/.github/workflows/server-test.yaml
@@ -33,7 +33,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          # Pinned to 2.7.14: newer v2.x releases broke the native-transport
+          # E2E tests. A node:net server binding a named pipe (Windows) or
+          # unix socket now raises NotCapable despite --allow-read/--allow-write,
+          # demanding --allow-all. Same area as denoland/deno#33366 (the bug
+          # #52 pinned around). Revisit once resolved upstream.
+          deno-version: v2.7.14
       - run: deno task test
         working-directory: server
       - run: deno task test:e2e

--- a/server/tests/helpers/browser_client.ts
+++ b/server/tests/helpers/browser_client.ts
@@ -9,7 +9,7 @@ export class BrowserClient {
   #waiters: Array<{
     predicate: (msg: ServerMessage) => boolean;
     resolve: (msg: ServerMessage) => void;
-    timer: number;
+    timer: ReturnType<typeof setTimeout>;
   }> = [];
 
   /** Connect to the server's WebSocket endpoint. */

--- a/server/tests/helpers/r_client.ts
+++ b/server/tests/helpers/r_client.ts
@@ -221,7 +221,7 @@ function createCancellableTimeout(ms: number): {
   promise: Promise<null>;
   cancel: () => void;
 } {
-  let timer: number;
+  let timer: ReturnType<typeof setTimeout>;
   const promise = new Promise<null>((resolve) => {
     timer = setTimeout(() => resolve(null), ms);
   });

--- a/tests/bench/run.ts
+++ b/tests/bench/run.ts
@@ -69,7 +69,7 @@ function createStreamCollector(stream: ReadableStream<Uint8Array> | null) {
 }
 
 async function waitUpTo<T>(promise: Promise<T>, waitMs: number): Promise<void> {
-  let timeoutId: number | undefined;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   await Promise.race([
     promise.then(() => undefined).catch(() => undefined),
     new Promise<void>((resolve) => {

--- a/tests/bench/timeout.ts
+++ b/tests/bench/timeout.ts
@@ -4,7 +4,7 @@ export function raceWithTimeout<T>(
   onTimeout: () => void | Promise<void>,
   message: string,
 ): Promise<T> {
-  let timeoutId: number | undefined;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
       try {

--- a/tests/helpers/arf_session.ts
+++ b/tests/helpers/arf_session.ts
@@ -58,7 +58,7 @@ export class ArfSession {
       this.#process = process;
       const startupId = ++this.#startupId;
 
-      let timeoutId: number | undefined;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
       const timeout = new Promise<never>((_, reject) => {
         timeoutId = setTimeout(
           () =>
@@ -241,7 +241,7 @@ export class ArfSession {
       stderr: "null",
     }).spawn();
 
-    let timeoutId: number | undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(() => {
         try {


### PR DESCRIPTION
## What

CI-only fixes for E2E failures caused by Deno `v2.x` drift since the last green run. **Orthogonal to #66** (vscode-ext deprecation); split out so that PR stays focused.

Two independent breakages:

1. **`setTimeout` return-type change** (`TS2322`) — newer Deno changed `setTimeout`'s return from `number` to a branded `Timeout`. Fixed by annotating timer handles with `ReturnType<typeof setTimeout>` (durable, runtime-agnostic; keeps full type-checking — no `any`/`--no-check`).
2. **Native-transport `NotCapable`** — a `node:net` server binding a named pipe (Windows) / unix socket now raises `NotCapable` despite `--allow-read`/`--allow-write`, demanding `--allow-all`. TCP transport is unaffected. Same area as denoland/deno#33366 (pinned around in #52, unpinned in #57). Re-pinned both `e2e-test` and `server-test` workflows to `v2.7.14` pending upstream resolution.

## Notes

- The `setTimeout` fix is a strict improvement and harmless on any Deno version.
- The pin is the reversible, no-permission-loss option (vs. loosening the test server to `--allow-all`). The deeper "support latest v2.x" question is left for a follow-up — cc @eitsupi.

## Test plan

- [ ] E2E green on ubuntu + windows
- [ ] Test server green