### PR TITLE
test(server): fix Deno 2.8+ NotCapable regressions for unix sockets and Windows named pipes

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -52,12 +52,7 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          # Pinned to 2.7.14: newer v2.x releases broke the native-transport
-          # E2E tests. A node:net server binding a named pipe (Windows) or
-          # unix socket now raises NotCapable despite --allow-read/--allow-write,
-          # demanding --allow-all. Same area as denoland/deno#33366 (the bug
-          # #52 pinned around). Revisit once resolved upstream.
-          deno-version: v2.7.14
+          deno-version: v2.x
 
       - name: Install arf
         run: |

--- a/.github/workflows/server-test.yaml
+++ b/.github/workflows/server-test.yaml
@@ -33,12 +33,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
         with:
-          # Pinned to 2.7.14: newer v2.x releases broke the native-transport
-          # E2E tests. A node:net server binding a named pipe (Windows) or
-          # unix socket now raises NotCapable despite --allow-read/--allow-write,
-          # demanding --allow-all. Same area as denoland/deno#33366 (the bug
-          # #52 pinned around). Revisit once resolved upstream.
-          deno-version: v2.7.14
+          deno-version: v2.x
       - run: deno task test
         working-directory: server
       - run: deno task test:e2e

--- a/server/deno.json
+++ b/server/deno.json
@@ -17,8 +17,17 @@
     // --allow-net is the documented escape hatch for that case.
     "start": "deno run --allow-net --allow-read --allow-write --allow-env main.ts",
     "dev": "deno run --allow-net --allow-read --allow-write --allow-env --watch main.ts",
-    "test": "deno test --allow-net --allow-read --allow-write --allow-env --allow-run=deno --parallel --ignore=tests/e2e tests/",
-    "test:e2e": "deno test --allow-env --allow-net --allow-read --allow-write --allow-run tests/e2e/",
+    // -A is required here (not just --allow-net/read/write/env): on Windows,
+    // node:net's PipeWrap.bind/listen/connect (used for named pipes) routes
+    // any non-drive-letter path like \\.\pipe\... through Deno's permission
+    // checker's check_special_file, which demands every permission category
+    // (read/write/net/env/sys/run/ffi/import) be fully granted -- i.e. -A
+    // itself, with no narrower combination accepted. These tasks exercise
+    // that code path directly (in-process pipe tests) or indirectly (via
+    // TestServer spawning main.ts), so they need -A on Windows; -A here for
+    // all platforms keeps the task portable without OS-specific branching.
+    "test": "deno test -A --parallel --ignore=tests/e2e tests/",
+    "test:e2e": "deno test -A tests/e2e/",
     "test:all": "deno task test && deno task test:e2e"
   }
 }

--- a/server/deno.json
+++ b/server/deno.json
@@ -8,10 +8,16 @@
     "@astral/astral": "jsr:@astral/astral@^0.5"
   },
   "tasks": {
-    "start": "deno run --allow-net=127.0.0.1 --allow-read --allow-write --allow-env main.ts",
-    "dev": "deno run --allow-net=127.0.0.1 --allow-read --allow-write --allow-env --watch main.ts",
-    "test": "deno test --allow-net=127.0.0.1 --allow-read --allow-write --allow-env --allow-run=deno --parallel --ignore=tests/e2e tests/",
-    // --allow-net is unrestricted: Astral downloads Chrome from googlechromelabs.github.io on CI
+    // --allow-net is unrestricted (not scoped to 127.0.0.1): since Deno
+    // PR denoland/deno#34395, Deno.listen/connect({transport:"unix"}) also
+    // requires an --allow-net=unix:<path> grant, in addition to
+    // --allow-read/--allow-write, to bind/connect the R unix socket. The
+    // socket path is randomly generated at runtime when --socket isn't
+    // passed explicitly, so it can't be allow-listed up front; unscoped
+    // --allow-net is the documented escape hatch for that case.
+    "start": "deno run --allow-net --allow-read --allow-write --allow-env main.ts",
+    "dev": "deno run --allow-net --allow-read --allow-write --allow-env --watch main.ts",
+    "test": "deno test --allow-net --allow-read --allow-write --allow-env --allow-run=deno --parallel --ignore=tests/e2e tests/",
     "test:e2e": "deno test --allow-env --allow-net --allow-read --allow-write --allow-run tests/e2e/",
     "test:all": "deno task test && deno task test:e2e"
   }

--- a/server/tests/helpers/server.ts
+++ b/server/tests/helpers/server.ts
@@ -64,7 +64,10 @@ export class TestServer {
       bin = "deno";
       prefixArgs = [
         "run",
-        "--allow-net=127.0.0.1",
+        // --allow-net is unrestricted: see comment in server/deno.json on
+        // why Deno.listen({transport:"unix"}) needs unscoped --allow-net
+        // for a socket path that's only known after the process starts.
+        "--allow-net",
         "--allow-read",
         "--allow-write",
         "--allow-env",

--- a/server/tests/helpers/server.ts
+++ b/server/tests/helpers/server.ts
@@ -64,13 +64,10 @@ export class TestServer {
       bin = "deno";
       prefixArgs = [
         "run",
-        // --allow-net is unrestricted: see comment in server/deno.json on
-        // why Deno.listen({transport:"unix"}) needs unscoped --allow-net
-        // for a socket path that's only known after the process starts.
-        "--allow-net",
-        "--allow-read",
-        "--allow-write",
-        "--allow-env",
+        // -A is required: see comment in server/deno.json on why Windows
+        // named pipe binding needs the full -A grant, not just
+        // --allow-net/read/write/env.
+        "-A",
         join(dirname(fromFileUrl(import.meta.url)), "..", "..", "main.ts"),
       ];
     }

--- a/tests/deno.json
+++ b/tests/deno.json
@@ -7,11 +7,17 @@
     "@astral/astral": "jsr:@astral/astral@^0.5"
   },
   "tasks": {
-    // --allow-run and --allow-net are unrestricted: E2E tests spawn R,
-    // Rscript, and deno subprocesses, and Astral launches a Chromium binary
-    // from a versioned cache path that cannot be allow-listed statically.
-    "test": "deno test --allow-net --allow-read --allow-write --allow-env --allow-run .",
-    "test:fail-fast": "deno test --fail-fast --allow-net --allow-read --allow-write --allow-env --allow-run .",
+    // -A is required (not just --allow-net/read/write/env/run): E2E tests
+    // spawn an actual jgd server, which on Windows binds a named pipe via
+    // node:net's PipeWrap. That path routes any non-drive-letter path like
+    // \\.\pipe\... through Deno's check_special_file, which demands every
+    // permission category be fully granted -- i.e. -A itself, with no
+    // narrower combination accepted. -A here for all platforms keeps the
+    // task portable without OS-specific branching; it also covers spawning
+    // R/Rscript/deno subprocesses and Astral's Chromium binary, which can't
+    // be allow-listed statically either.
+    "test": "deno test -A .",
+    "test:fail-fast": "deno test --fail-fast -A .",
     "bench": "deno run --allow-all bench/run.ts"
   }
 }


### PR DESCRIPTION
## What

Follow-up to #67 — replaces the `v2.7.14` pin with the actual fix for two related `NotCapable` regressions in Deno 2.8+: one on the native Unix-domain-socket transport (Linux/macOS), one on Windows named pipes.

## Root cause

Investigated against the denoland/deno source (v2.9.0, matching the version resolved by `deno-version: v2.x` in CI).

### Unix domain sockets (Linux/macOS)

Introduced by [denoland/deno#34395](https://github.com/denoland/deno/pull/34395), a deliberate security hardening: `Deno.listen`/`Deno.connect({transport: "unix"})` now also require an `--allow-net=unix:<path>` grant, in addition to filesystem read/write permission, to bind/connect a Unix domain socket. This won't be reverted upstream.

Our R socket path is generated at runtime when `--socket` isn't passed explicitly, so it can't be allow-listed up front (`--allow-net` matching is exact-path only — no wildcard/prefix support). Deno's documented escape hatch is unscoped `--allow-net` (not `--allow-all`), which resolves this while keeping `--allow-read`/`--allow-write`/`--allow-env` scoped as before.

### Windows named pipes

A second, more restrictive regression: `node:net`'s `PipeWrap::bind/listen/connect` (used by our `PipeListener`/`PipeConn` for Windows named pipes) calls Deno's `check_open`, which on Windows routes any path that isn't a normalized drive-letter path (e.g. `\\.\pipe\...`) through `check_special_file` → `check_has_all_permissions`. That function requires *every* permission category (`read`/`write`/`net`/`env`/`sys`/`run`/`ffi`/`import`) to be fully granted — i.e. `-A`/`--allow-all` itself, with no narrower combination accepted (there's no special-case allowance for `\\.\pipe\...`, unlike `\\.\nul`). So no combination of scoped or unscoped `--allow-net`/`--allow-read`/`--allow-write`/`--allow-env` flags can satisfy it — `-A` is required whenever the process binds/connects a Windows named pipe.

This only affects test/dev tasks that spawn or exercise the pipe adapter directly; the `start`/`dev` tasks (which aren't invoked by CI) are left with their existing scoped flags.

## Changes

- `server/deno.json`: `start`/`dev` tasks — `--allow-net=127.0.0.1` → unscoped `--allow-net` (unchanged from earlier in this PR). `test`/`test:e2e` tasks → `-A` (needed for Windows named pipe tests)
- `server/tests/helpers/server.ts`: `TestServer` subprocess args → `-A`
- `tests/deno.json`: `test`/`test:fail-fast` tasks → `-A` (E2E tests spawn the real server, which binds a named pipe on Windows)
- `.github/workflows/e2e-test.yaml`, `.github/workflows/server-test.yaml`: unpin `deno-version` back to `v2.x`

## Testing

- `cd server && deno task test` — 36 passed, 1 failed (`metrics_test.ts` timing assertion, flaky under parallel load — passes in isolation, unrelated to this change)
- `cd server && deno task test:e2e` — non-browser assertions pass; the 14 Astral/Chromium-driven tests fail with `No usable sandbox!` in this sandboxed dev container (pre-existing environment limitation, unrelated to this change) — no `NotCapable` errors anywhere in the output
- `cd tests && deno check .` — type-checks clean

## Test plan

- [ ] CI green on ubuntu + windows for both E2E test and Test server workflows
