### PR TITLE
docs(server): document Windows -A requirement for named pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,11 @@ First [install Deno](https://docs.deno.com/runtime/getting_started/installation/
 then run directly (dependencies are fetched automatically):
 
 ```bash
-deno run https://raw.githubusercontent.com/grantmcdermott/jgd/refs/heads/main/server/main.ts
+# macOS / Linux
+deno run --allow-net --allow-read --allow-write --allow-env https://raw.githubusercontent.com/grantmcdermott/jgd/refs/heads/main/server/main.ts
+
+# Windows
+deno run -A https://raw.githubusercontent.com/grantmcdermott/jgd/refs/heads/main/server/main.ts
 ```
 
 Or, clone the repo and run locally:
@@ -108,6 +112,19 @@ Or, clone the repo and run locally:
 # git clone https://github.com/grantmcdermott/jgd.git ## clone first
 cd server && deno task start && cd ..
 ```
+
+> [!NOTE]
+> On **Windows**, R connections default to a named pipe, and Deno has no
+> permission combination narrower than `-A` (`--allow-all`) that can satisfy
+> binding one — that's why the Windows command above needs it (`deno task
+> start` above already grants `-A` for the same reason).
+>
+> To keep permissions scoped on Windows instead, add `--tcp <port>` (e.g.
+> `--tcp 8888`) to connect over localhost TCP rather than a named pipe:
+>
+> ```bash
+> deno run --allow-net --allow-read --allow-write --allow-env https://raw.githubusercontent.com/grantmcdermott/jgd/refs/heads/main/server/main.ts --tcp 8888
+> ```
 
 Once the Deno server is running, open `http://127.0.0.1:<port>/`
 in your browser (the URL is printed on startup). Then you start executing

--- a/server/deno.json
+++ b/server/deno.json
@@ -8,24 +8,22 @@
     "@astral/astral": "jsr:@astral/astral@^0.5"
   },
   "tasks": {
-    // --allow-net is unrestricted (not scoped to 127.0.0.1): since Deno
-    // PR denoland/deno#34395, Deno.listen/connect({transport:"unix"}) also
-    // requires an --allow-net=unix:<path> grant, in addition to
-    // --allow-read/--allow-write, to bind/connect the R unix socket. The
-    // socket path is randomly generated at runtime when --socket isn't
-    // passed explicitly, so it can't be allow-listed up front; unscoped
-    // --allow-net is the documented escape hatch for that case.
-    "start": "deno run --allow-net --allow-read --allow-write --allow-env main.ts",
-    "dev": "deno run --allow-net --allow-read --allow-write --allow-env --watch main.ts",
-    // -A is required here (not just --allow-net/read/write/env): on Windows,
-    // node:net's PipeWrap.bind/listen/connect (used for named pipes) routes
+    // -A (--allow-all) is required on Windows: R connections default to a
+    // named pipe there, and node:net's PipeWrap.bind/listen/connect routes
     // any non-drive-letter path like \\.\pipe\... through Deno's permission
     // checker's check_special_file, which demands every permission category
     // (read/write/net/env/sys/run/ffi/import) be fully granted -- i.e. -A
-    // itself, with no narrower combination accepted. These tasks exercise
-    // that code path directly (in-process pipe tests) or indirectly (via
-    // TestServer spawning main.ts), so they need -A on Windows; -A here for
-    // all platforms keeps the task portable without OS-specific branching.
+    // itself, with no narrower combination accepted. Separately, on
+    // Linux/macOS, Deno.listen({transport:"unix"}) requires an unscoped
+    // --allow-net (since denoland/deno#34395) because the R socket path is
+    // randomly generated at runtime and can't be allow-listed up front.
+    // -A satisfies both without OS-specific branching (deno.json tasks
+    // can't conditionally vary flags by platform). Passing --tcp <port> to
+    // these tasks avoids named pipes/unix sockets entirely and only needs
+    // --allow-net --allow-read --allow-write --allow-env, if narrower
+    // permissions are preferred over -A.
+    "start": "deno run -A main.ts",
+    "dev": "deno run -A --watch main.ts",
     "test": "deno test -A --parallel --ignore=tests/e2e tests/",
     "test:e2e": "deno test -A tests/e2e/",
     "test:all": "deno task test && deno task test:e2e"

--- a/server/deno.json
+++ b/server/deno.json
@@ -18,10 +18,11 @@
     // --allow-net (since denoland/deno#34395) because the R socket path is
     // randomly generated at runtime and can't be allow-listed up front.
     // -A satisfies both without OS-specific branching (deno.json tasks
-    // can't conditionally vary flags by platform). Passing --tcp <port> to
-    // these tasks avoids named pipes/unix sockets entirely and only needs
-    // --allow-net --allow-read --allow-write --allow-env, if narrower
-    // permissions are preferred over -A.
+    // can't conditionally vary flags by platform). -A is hardcoded into
+    // these tasks, so passing --tcp <port> here does NOT narrow permissions
+    // (deno task start -- --tcp 8888 still runs with -A). To actually get
+    // scoped permissions with --tcp, invoke `deno run` directly instead of
+    // this task -- see the README's Deno-server quick-start section.
     "start": "deno run -A main.ts",
     "dev": "deno run -A --watch main.ts",
     "test": "deno test -A --parallel --ignore=tests/e2e tests/",


### PR DESCRIPTION
## Summary
- Windows named-pipe binding always falls into Deno's `check_has_all_permissions`, which only `-A`/`--allow-all` can satisfy — no combination of scoped `--allow-net`/`--allow-read`/`--allow-write`/`--allow-env` works (confirmed by reading Deno's `check_special_file`, the same regression fixed for the test tasks in #69).
- `server/deno.json`'s `start`/`dev` tasks were left scoped in #69 since they aren't exercised by CI, but that means real Windows users following the README's quick-start hit this wall. Unify `start`/`dev` to `-A` (matching `test`/`test:e2e`) since `deno.json` tasks can't branch by OS.
- Update the README's Deno-server quick-start with an explicit Windows command (`-A`) alongside the macOS/Linux one, and a callout documenting a `--tcp <port>` fallback for users who want to keep permissions scoped on Windows (bypasses named pipes entirely).

## Upstream context

This isn't something jgd can fix on its own — it's Deno's permission model:

- [denoland/deno#26045](https://github.com/denoland/deno/issues/26045) covers the same underlying code path (Windows device/network paths falling into `check_special_file` → `check_has_all_permissions` with no scoped alternative and no prompt), though it doesn't name named pipes specifically.
- [denoland/deno#35617](https://github.com/denoland/deno/issues/35617) is a more general, more recent complaint about the same class of problem: Deno throwing `NotCapable` without ever offering a permission prompt for the missing grant, which matches what we hit here.
- We're forced through this code path at all because `Deno.connect` has no native named-pipe transport ([denoland/deno#10244](https://github.com/denoland/deno/issues/10244)), so named-pipe support goes through the `node:net` compat layer's `PipeWrap`, which is what trips the all-or-nothing check.
- There is precedent for Deno carving out narrower exceptions for specific special-file cases (`/dev/tty` in [denoland/deno#31105](https://github.com/denoland/deno/pull/31105)), so a similar fix for named pipes isn't out of the question upstream, but nothing tracks it today.

## Test plan
- [ ] `cd server && deno task test` — confirm still green
- [ ] `cd server && deno task test:e2e` — confirm still green
- [ ] Manually verify `deno run -A main.ts` and `deno run ... main.ts --tcp 8888` both still start the server as documented
